### PR TITLE
Add appveyor config and badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# HELICS-SRC [![Build Status](https://travis-ci.org/GMLC-TDC/HELICS-src.svg?branch=master)](https://travis-ci.org/GMLC-TDC/HELICS-src) [![Gitter chat](https://badges.gitter.im/GMLC-TDC/HELICS-src.png)](https://gitter.im/GMLC-TDC/HELICS-src)
+# HELICS-SRC [![Build Status](https://travis-ci.org/GMLC-TDC/HELICS-src.svg?branch=master)](https://travis-ci.org/GMLC-TDC/HELICS-src) [![Build status](https://ci.appveyor.com/api/projects/status/re4ximd0eaalfvia?svg=true)](https://ci.appveyor.com/project/nightlark/helics-src) [![Gitter chat](https://badges.gitter.im/GMLC-TDC/HELICS-src.png)](https://gitter.im/GMLC-TDC/HELICS-src)
 
 Repository for the source code for the Hierarchical Engine for Large-scale Infrastructure Co-Simulation (HELICS) tool.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+shallow_clone: true
+
+version: 0.3.{build}
+
+image: Visual Studio 2015
+
+platform:
+  - x64
+
+configuration:
+  - Release
+
+install:
+
+before_build:
+  - mkdir build
+  - cd build
+  - cmake .. -G "Visual Studio 14 2015 Win64" -DAUTOBUILD_ZMQ=ON  -DBUILD_SHARED_LIBS=ON -DBUILD_HELICS_EXAMPLES=ON -DBOOST_ROOT="C:\Libraries\boost_1_62_0"
+  - cd ..
+
+build:
+  project: build/HELICS.sln
+  parallel: true
+  verbosity: minimal
+
+after_build:
+
+artifacts:


### PR DESCRIPTION
Build on Windows using Appveyor (#10).

Eventually we should create an Appveyor account using a "helics" email address for the builds and update the links for the badge/build status.