### PR TITLE
Separate CXX standard detection from config, remove CMAKE_REQUIRED_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,15 @@ ENDIF(MSVC)
   ENDIF(MINGW)
 ENDIF(UNIX)
 
+# -------------------------------------------------------------
+# Check and set latest CXX Standard supported by compiler
+# -------------------------------------------------------------
+include(CheckLatestCXXStandardOption)
+IF (VERSION_OPTION)
+	add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${VERSION_OPTION}>)
+ELSE ()
+set(CMAKE_CXX_STANDARD 14)
+ENDIF ()
 
 # -------------------------------------------------------------
 # add threading support
@@ -124,13 +133,6 @@ find_package(Threads REQUIRED)
 #message(STATUS ${CMAKE_CXX_FLAGS})
 set(CONFIGURE_TARGET_LOCATION ${PROJECT_BINARY_DIR}/libs/include/helics/)
 include(configGenerator)
-
-IF (VERSION_OPTION)
-	add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${VERSION_OPTION}>)
-ELSE ()
-set(CMAKE_CXX_STANDARD 14)
-ENDIF ()
-
 
 option (HELICS_GENERATE_DOXYGEN_DOC "Generate Doxygen doc target" OFF)
 

--- a/cmake/modules/CheckLatestCXXStandardOption.cmake
+++ b/cmake/modules/CheckLatestCXXStandardOption.cmake
@@ -1,0 +1,33 @@
+# LLNS Copyright Start
+# Copyright (c) 2017, Lawrence Livermore National Security
+# This work was performed under the auspices of the U.S. Department 
+# of Energy by Lawrence Livermore National Laboratory in part under 
+# Contract W-7405-Eng-48 and in part under Contract DE-AC52-07NA27344.
+# Produced at the Lawrence Livermore National Laboratory.
+# All rights reserved.
+# For details, see the LICENSE file.
+# LLNS Copyright End
+
+
+
+#check for clang 3.4 and the fact that CMAKE_CXX_STANDARD doesn't work yet for that compiler
+
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.5)
+	set(VERSION_OPTION -std=c++1y)
+  else ()
+    set(VERSION_OPTION -std=c++1z)
+  endif()
+elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+  # c++14 becomes default in GCC 6.1
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.1)
+    set(VERSION_OPTION -std=c++1y)
+  else ()
+    set(VERSION_OPTION -std=c++1z)
+  endif()
+endif()
+
+#boost libraries don't compile under /std:c++latest flag 1.66 might solve this issue
+#if (MSVC)
+#set(VERSION_OPTION /std:c++latest)
+#endif()

--- a/cmake/modules/configGenerator.cmake
+++ b/cmake/modules/configGenerator.cmake
@@ -8,34 +8,6 @@
 # For details, see the LICENSE file.
 # LLNS Copyright End
 
-
-
-#check for clang 3.4 and the fact that CMAKE_CXX_STANDARD doesn't work yet for that compiler
-
-if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.5)
-    set(CMAKE_REQUIRED_FLAGS -std=c++1y)
-	set(VERSION_OPTION -std=c++1y)
-  else ()
-    set(CMAKE_REQUIRED_FLAGS -std=c++1z)
-    set(VERSION_OPTION -std=c++1z)
-  endif()
-elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
-  # c++14 becomes default in GCC 6.1
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.1)
-    set(CMAKE_REQUIRED_FLAGS -std=c++1y)
-    set(VERSION_OPTION -std=c++1y)
-  else ()
-    set(CMAKE_REQUIRED_FLAGS -std=c++1z)
-    set(VERSION_OPTION -std=c++1z)
-  endif()
-endif()
-
-#boost libraries don't compile under /std:c++latest flag 1.66 might solve this issue
-#if (MSVC)
-#set(VERSION_OPTION /std:c++latest)
-#endif()
-
 if ( MSVC )
     set(WERROR_FLAG "/W4")
 else( MSVC )


### PR DESCRIPTION
Separates the CXX standard detection out of the config generator script, and sets the standard using add_compile_options -- result gets propagated to try_compile calls.

Avoid using CMAKE_REQUIRED_FLAGS. It seems to be undocumented (internal use only?) and caused problems with FindThreads when used.