### PR TITLE
Correct missing newline at end of shared_api_library/MessageFilters.h

### DIFF
--- a/src/helics/shared_api_library/MessageFilters.h
+++ b/src/helics/shared_api_library/MessageFilters.h
@@ -79,3 +79,4 @@ HELICS_Export helics_status helicsFilterRemoveDeliveryEndpoint(helics_filter fil
 #endif
 
 #endif /* HELICS_APISHARED_MESSAGE_FILTER_FEDERATE_FUNCTIONS_H_*/
+


### PR DESCRIPTION
One line change. Removes warning during  make with python extension on OSX

````
Scanning dependencies of target _helics
[100%] Building C object swig/python/CMakeFiles/_helics.dir/helicsPYTHON_wrap.c.o
In file included from /Users/bpalmint/repos/HELICS-src/build-osx/swig/python/helicsPYTHON_wrap.c:3032:
/Users/bpalmint/repos/HELICS-src/src/helics/shared_api_library/MessageFilters.h:81:66: warning: no newline at end of file
      [-Wnewline-eof]
#endif /* HELICS_APISHARED_MESSAGE_FILTER_FEDERATE_FUNCTIONS_H_*/
                                                                 ^
1 warning generated.
````