### PR TITLE
C++98 API library and IDE targets

### DIFF
--- a/examples/CppInterface/CMakeLists.txt
+++ b/examples/CppInterface/CMakeLists.txt
@@ -11,20 +11,20 @@ include_directories ("${PROJECT_SOURCE_DIR}/src/helics/cpp98")
 add_executable(pi_sender_cpp pi_sender.cpp)
 add_executable(pi_receiver_cpp pi_receiver.cpp)
 
-target_link_libraries(pi_sender_cpp helicsSharedLib )
-target_link_libraries(pi_receiver_cpp helicsSharedLib )
+target_link_libraries(pi_sender_cpp helicsCpp98 )
+target_link_libraries(pi_receiver_cpp helicsCpp98 )
 
 add_executable(pi_sender2_cpp pi_sender2.cpp)
 add_executable(pi_receiver2_cpp pi_receiver2.cpp)
 
-target_link_libraries(pi_sender2_cpp helicsSharedLib )
-target_link_libraries(pi_receiver2_cpp helicsSharedLib )
+target_link_libraries(pi_sender2_cpp helicsCpp98 )
+target_link_libraries(pi_receiver2_cpp helicsCpp98 )
 
 add_executable(nonlings_fed1_cpp nonlings_fed1.cpp)
 add_executable(nonlings_fed2_cpp nonlings_fed2.cpp)
 
-target_link_libraries(nonlings_fed1_cpp helicsSharedLib )
-target_link_libraries(nonlings_fed2_cpp helicsSharedLib )
+target_link_libraries(nonlings_fed1_cpp helicsCpp98 )
+target_link_libraries(nonlings_fed2_cpp helicsCpp98 )
 
 if (!MSVC)
 target_compile_options(pi_sender_cpp PRIVATE -std=c++98 -pedantic)

--- a/src/helics/CMakeLists.txt
+++ b/src/helics/CMakeLists.txt
@@ -17,7 +17,5 @@ ENDIF()
 if (BUILD_C_SHARED_LIB OR BUILD_PYTHON OR BUILD_MATLAB OR BUILD_JAVA)
 add_subdirectory(shared_api_library)
 add_subdirectory(cpp98)
-install(DIRECTORY cpp98 DESTINATION include/cpp98
-        FILES_MATCHING PATTERN "*.h*")
 install(FILES chelics.h DESTINATION include/helics)
 endif()

--- a/src/helics/CMakeLists.txt
+++ b/src/helics/CMakeLists.txt
@@ -16,6 +16,7 @@ ENDIF()
 
 if (BUILD_C_SHARED_LIB OR BUILD_PYTHON OR BUILD_MATLAB OR BUILD_JAVA)
 add_subdirectory(shared_api_library)
+add_subdirectory(cpp98)
 install(DIRECTORY cpp98 DESTINATION include/cpp98
         FILES_MATCHING PATTERN "*.h*")
 install(FILES chelics.h DESTINATION include/helics)

--- a/src/helics/cpp98/CMakeLists.txt
+++ b/src/helics/cpp98/CMakeLists.txt
@@ -13,9 +13,9 @@ ValueFederate.hpp
 helics.hpp
 )
 
-add_library(helicsCpp98 INTERFACE)
-target_include_directories(helicsCpp98 INTERFACE "${PROJECT_SOURCE_DIR}/src/helics")
-target_link_library(helicsCpp98 INTERFACE helicsSharedLib)
-target_sources(helicsCpp98 INTERFACE ${helicsCpp98_headers})
+add_library(helicsCpp98 STATIC ${helicsCpp98_headers})
+set_target_properties(helicsCpp98 PROPERTIES LINKER_LANGUAGE CXX)
+target_include_directories(helicsCpp98 PUBLIC "${PROJECT_SOURCE_DIR}/src/helics")
+target_link_libraries(helicsCpp98 INTERFACE helicsSharedLib)
 
 install(FILES ${helicsCpp98_headers} DESTINATION include/cpp98)

--- a/src/helics/cpp98/CMakeLists.txt
+++ b/src/helics/cpp98/CMakeLists.txt
@@ -1,0 +1,21 @@
+##############################################################################
+#Copyright (C) 2017-2018, Battelle Memorial Institute
+#All rights reserved.
+
+#This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
+##############################################################################
+set(helicsCpp98_headers
+Broker.hpp
+CombinationFederate.hpp
+Federate.hpp
+MessageFederate.hpp
+ValueFederate.hpp
+helics.hpp
+)
+
+add_library(helicsCpp98 INTERFACE)
+target_include_directories(helicsCpp98 INTERFACE "${PROJECT_SOURCE_DIR}/src/helics")
+target_link_library(helicsCpp98 INTERFACE helicsSharedLib)
+target_sources(helicsCpp98 INTERFACE ${helicsCpp98_headers})
+
+install(FILES ${helicsCpp98_headers} DESTINATION include/cpp98)

--- a/src/helics/cpp98/CMakeLists.txt
+++ b/src/helics/cpp98/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(helicsCpp98 INTERFACE)
 target_include_directories(helicsCpp98 INTERFACE "${PROJECT_SOURCE_DIR}/src/helics")
 target_link_libraries(helicsCpp98 INTERFACE helicsSharedLib)
 
-add_custom_target(helicsCpp98_ide SOURCES ${helicsCpp98_headers})
+add_library(helicsCpp98_ide STATIC ${helicsCpp98_headers} ../../empty.cpp)
+target_include_directories(helicsCpp98_ide PRIVATE "${PROJECT_SOURCE_DIR}/src/helics")
 
 install(FILES ${helicsCpp98_headers} DESTINATION include/cpp98)

--- a/src/helics/cpp98/CMakeLists.txt
+++ b/src/helics/cpp98/CMakeLists.txt
@@ -13,9 +13,10 @@ ValueFederate.hpp
 helics.hpp
 )
 
-add_library(helicsCpp98 STATIC ${helicsCpp98_headers})
-set_target_properties(helicsCpp98 PROPERTIES LINKER_LANGUAGE CXX)
-target_include_directories(helicsCpp98 PUBLIC "${PROJECT_SOURCE_DIR}/src/helics")
+add_library(helicsCpp98 INTERFACE)
+target_include_directories(helicsCpp98 INTERFACE "${PROJECT_SOURCE_DIR}/src/helics")
 target_link_libraries(helicsCpp98 INTERFACE helicsSharedLib)
+
+add_custom_target(helicsCpp98_ide SOURCES ${helicsCpp98_headers})
 
 install(FILES ${helicsCpp98_headers} DESTINATION include/cpp98)

--- a/src/helics/cpp98/CombinationFederate.hpp
+++ b/src/helics/cpp98/CombinationFederate.hpp
@@ -11,8 +11,8 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 #define HELICS_CPP98_COMBINATION_FEDERATE_HPP_
 #pragma once
 
-#include "MessageFederate.hpp"
 #include "ValueFederate.hpp"
+#include "MessageFederate.hpp"
 
 namespace helics
 {


### PR DESCRIPTION
Adds a target to make the C++98 API header files show up in IDEs (Visual Studio, issue #104). Creates a helicsCpp98 interface library that can be used for target_link_libraries command.