### PR TITLE
Update version of Boost used on Travis, commit keyword to update cached dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,9 @@ jobs:
             - ubuntu-toolchain-r-test
           packages:
             - g++-4.9
-      env: MATRIX_EVAL="COMPILER=g++-4.9 && CC=gcc-4.9 && CXX=g++-4.9"
+      env:
+        - MATRIX_EVAL="COMPILER=g++-4.9 && CC=gcc-4.9 && CXX=g++-4.9"
+        - MINIMUM_DEPENDENCIES=true
 
     - <<: *linux_base
       compiler: clang

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -34,8 +34,8 @@ install_boost () {
     # Split argument 1 into 'ver' array, with '.' as delimiter
     local -a ver
     IFS='.' read -r -a ver <<< $1
-    local boost_version = $1
-    local boost_version_str = boost_${ver[0]}_${ver[1]}_${ver[2]}
+    local boost_version=$1
+    local boost_version_str=boost_${ver[0]}_${ver[1]}_${ver[2]}
     wget -O ${boost_version_str}.tar.gz http://sourceforge.net/projects/boost/files/boost/${boost_version}/${boost_version_str}.tar.gz/download && tar xzf boost_$1_$2_$3.tar.gz
     (
         cd ${boost_version_str}/;

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -19,6 +19,13 @@ fi
 export PATH="$HOME/swig/bin:${PATH}"
 echo "*** built swig successfully {$PATH}"
 
+# Convert commit message to lower case
+commit_msg=`tr '[:upper:]' '[:lower:]' <<< ${TRAVIS_COMMIT_MESSAGE}`
+# Wipe out the dependencies directory if commit message has '[update_cache]'
+if [[ $commit_msg == *'[update_cache]'* ]]; then
+    rm -rf dependencies;
+fi
+
 if [[ ! -f "dependencies" ]]; then
     mkdir -p dependencies;
 fi

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -36,7 +36,7 @@ install_boost () {
     IFS='.' read -r -a ver <<< $1
     local boost_version=$1
     local boost_version_str=boost_${ver[0]}_${ver[1]}_${ver[2]}
-    wget -O ${boost_version_str}.tar.gz http://sourceforge.net/projects/boost/files/boost/${boost_version}/${boost_version_str}.tar.gz/download && tar xzf boost_$1_$2_$3.tar.gz
+    wget -O ${boost_version_str}.tar.gz http://sourceforge.net/projects/boost/files/boost/${boost_version}/${boost_version_str}.tar.gz/download && tar xzf ${boost_version_str}.tar.gz
     (
         cd ${boost_version_str}/;
         ./bootstrap.sh --with-libraries=date_time,filesystem,program_options,system,test;
@@ -76,11 +76,10 @@ if [[ ! -d "dependencies/zmq" ]]; then
     )
     echo "*** built zmq successfully"
 fi
-
 # Install Boost
 if [[ ! -d "dependencies/boost" ]]; then
     echo "*** build boost"
-    if [[ "MINIMUM_DEPENDENCIES" == "true" ]]; then
+    if [[ "$MINIMUM_DEPENDENCIES" == "true" ]]; then
         install_boost 1.61.0
     else
         install_boost 1.65.0

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -24,9 +24,14 @@ if [[ ! -f "dependencies" ]]; then
 fi
 
 install_boost () {
-    wget -O boost_$1_$2_$3.tar.gz http://sourceforge.net/projects/boost/files/boost/$1.$2.$3/boost_$1_$2_$3.tar.gz/download && tar xzf boost_$1_$2_$3.tar.gz
+    # Split argument 1 into 'ver' array, with '.' as delimiter
+    local -a ver
+    IFS='.' read -r -a ver <<< $1
+    local boost_version = $1
+    local boost_version_str = boost_${ver[0]}_${ver[1]}_${ver[2]}
+    wget -O ${boost_version_str}.tar.gz http://sourceforge.net/projects/boost/files/boost/${boost_version}/${boost_version_str}.tar.gz/download && tar xzf boost_$1_$2_$3.tar.gz
     (
-        cd boost_$1_$2_$3/;
+        cd ${boost_version_str}/;
         ./bootstrap.sh --with-libraries=date_time,filesystem,program_options,system,test;
         ./b2 link=shared threading=multi variant=release > /dev/null;
         ./b2 install --prefix=../dependencies/boost > /dev/null;
@@ -69,9 +74,9 @@ fi
 if [[ ! -d "dependencies/boost" ]]; then
     echo "*** build boost"
     if [[ "MINIMUM_DEPENDENCIES" == "true" ]]; then
-        install_boost 1 61 0
+        install_boost 1.61.0
     else
-        install_boost 1 65 0
+        install_boost 1.65.0
     fi
     echo "*** built boost successfully"
 fi

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -23,6 +23,16 @@ if [[ ! -f "dependencies" ]]; then
     mkdir -p dependencies;
 fi
 
+install_boost () {
+    wget -O boost_$1_$2_$3.tar.gz http://sourceforge.net/projects/boost/files/boost/$1.$2.$3/boost_$1_$2_$3.tar.gz/download && tar xzf boost_$1_$2_$3.tar.gz
+    (
+        cd boost_$1_$2_$3/;
+        ./bootstrap.sh --with-libraries=date_time,filesystem,program_options,system,test;
+        ./b2 link=shared threading=multi variant=release > /dev/null;
+        ./b2 install --prefix=../dependencies/boost > /dev/null;
+    )
+}
+
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     if [[ ! -f "cmake-3.4.3-Linux-x86_64/bin/cmake" ]]; then
         echo "*** install cmake"
@@ -55,17 +65,17 @@ if [[ ! -d "dependencies/zmq" ]]; then
     echo "*** built zmq successfully"
 fi
 
+# Install Boost
 if [[ ! -d "dependencies/boost" ]]; then
     echo "*** build boost"
-    wget -O boost_1_61_0.tar.gz http://sourceforge.net/projects/boost/files/boost/1.61.0/boost_1_61_0.tar.gz/download && tar xzf boost_1_61_0.tar.gz
-    (
-        cd boost_1_61_0/;
-        ./bootstrap.sh --with-libraries=date_time,filesystem,program_options,system,test;
-        ./b2 link=shared threading=multi variant=release > /dev/null;
-        ./b2 install --prefix=../dependencies/boost > /dev/null;
-    )
+    if [[ "MINIMUM_DEPENDENCIES" == "true" ]]; then
+        install_boost 1 61 0
+    else
+        install_boost 1 65 0
+    fi
     echo "*** built boost successfully"
 fi
+export BOOST_ROOT=${TRAVIS_BUILD_DIR}/dependencies/boost}
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     sudo ldconfig ${PWD}/dependencies


### PR DESCRIPTION
* Uses Boost 1.65 for all builds except with gcc-4.9; configurations can be built using Boost 1.61 by adding a `MINIMUM_DEPENDENCIES=true` environment variable. Boost installation commands have been put in their own function.
* Recognizes `[update_cache]` in commit messages to purge the contents of the dependencies directory, or if the commit message also contains `boost` or `zmq`, it will only remove the dependencies mentioned in the commit message.

Addresses issues #128 and #108 