### PR TITLE
Test python extension on travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ dkms.conf
 __pycache__/
 *.py[cod]
 *$py.class
+.pytest_cache
 
 # C extensions
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,7 +135,7 @@ script:
   - ctest --verbose --timeout 120 -I 0,0,0,6
   - export PYTHONPATH="$(pwd)/swig/python"
   - python3 -m helics
-  - pytest -v ../tests/python_helics
+  - python3 -m pytest -v ../tests/python_helics
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ _basic_env:
   if: branch IN (master, develop)
   os: osx
   compiler: clang
-        
+
 jobs:
   # On weekdays, the backlog for waiting OS X builds is huge
   fast_finish: true
@@ -119,7 +119,7 @@ install:
 script:
   - mkdir build && cd build
   - export HELICS_DEPENDENCY_FLAGS="-DZeroMQ_INSTALL_PATH=${TRAVIS_BUILD_DIR}/dependencies/zmq -DBOOST_ROOT=${TRAVIS_BUILD_DIR}/dependencies/boost"
-  - export HELICS_OPTION_FLAGS="-DBUILD_C_SHARED_LIB=ON -DBUILD_HELICS_EXAMPLES=ON -DBUILD_PYTHON=ON -DTRAVIS_TESTS_ENABLE=ON"
+  - export HELICS_OPTION_FLAGS="-DBUILD_C_SHARED_LIB=ON -DBUILD_HELICS_EXAMPLES=ON -DBUILD_PYTHON=ON -DTRAVIS_TESTS_ENABLE=ON -DPYTHON_LIBRARY=$(python3-config --prefix)/lib/libpython3.6m.so -DPYTHON_INCLUDE_DIR=$(python3-config --prefix)/include/python3.6m/"
   - cmake .. ${HELICS_DEPENDENCY_FLAGS} ${HELICS_OPTION_FLAGS}
   - make -j2
   # For controlling which tests get run:
@@ -132,6 +132,9 @@ script:
   # 6 = travis-tests
   # - ctest --verbose --timeout 120 -I 0,0,0,1
   - ctest --verbose --timeout 120 -I 0,0,0,6
+  - export PYTHONPATH="$(pwd)/swig/python"
+  - python3 -m helics
+  - pytest -v ../tests/python_helics
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,11 +49,11 @@ jobs:
   include:
     # XCode 6.4, OS X 10.10
     - <<: *osx_base
-      env: MATRIX_EVAL="COMPILER=clang++ && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=64 HOMEBREW_NO_AUTO_UPDATE=1"
+      env: MATRIX_EVAL="COMPILER=clang++ && BUILD_TYPE=Release && SHARED_LIB_EXT=dylib && TRAVIS_XCODE_VERSION=64 HOMEBREW_NO_AUTO_UPDATE=1"
       osx_image: xcode6.4
     # XCode 7.3, OS X 10.11
     - <<: *osx_base
-      env: MATRIX_EVAL="COMPILER=clang++ && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=73 HOMEBREW_NO_AUTO_UPDATE=1"
+      env: MATRIX_EVAL="COMPILER=clang++ && BUILD_TYPE=Release && SHARED_LIB_EXT=dylib && TRAVIS_XCODE_VERSION=73 HOMEBREW_NO_AUTO_UPDATE=1"
       osx_image: xcode7.3
 
     # Built without errors on my clone from one of the changes made
@@ -69,7 +69,7 @@ jobs:
             - ubuntu-toolchain-r-test
           packages:
             - g++-6
-      env: MATRIX_EVAL="COMPILER=g++-6 && CC=gcc-6 && CXX=g++-6"
+      env: MATRIX_EVAL="COMPILER=g++-6 && CC=gcc-6 && CXX=g++-6 && SHARED_LIB_EXT=so"
 
     - <<: *linux_base
       addons:
@@ -79,7 +79,7 @@ jobs:
           packages:
             - g++-4.9
       env:
-        - MATRIX_EVAL="COMPILER=g++-4.9 && CC=gcc-4.9 && CXX=g++-4.9"
+        - MATRIX_EVAL="COMPILER=g++-4.9 && CC=gcc-4.9 && CXX=g++-4.9 && SHARED_LIB_EXT=so"
         - MINIMUM_DEPENDENCIES=true
 
     - <<: *linux_base
@@ -91,18 +91,19 @@ jobs:
             - llvm-toolchain-precise-3.6
           packages:
             - clang-3.6
-      env: MATRIX_EVAL="COMPILER=clang++-3.6 && CC='ccache clang-3.6 -Qunused-arguments -fcolor-diagnostics' && CXX='ccache clang++-3.6 -Qunused-arguments -fcolor-diagnostics'
+      env: MATRIX_EVAL="SHARED_LIB_EXT=so && COMPILER=clang++-3.6 && CC='ccache clang-3.6 -Qunused-arguments -fcolor-diagnostics' && CXX='ccache clang++-3.6 -Qunused-arguments -fcolor-diagnostics'
+
 
    # ------------------------------------------------
    # Jobs for daily valgrind and code coverage tests
    # ------------------------------------------------
     - <<: *daily_linux
       env:
-        - MATRIX_EVAL="COMPILER=g++-6 && CC=gcc-6 && CXX=g++-6"
+        - MATRIX_EVAL="COMPILER=g++-6 && CC=gcc-6 && CXX=g++-6 && SHARED_LIB_EXT=so"
         - RUN_VALGRIND=true
     - <<: *daily_linux
       env:
-        - MATRIX_EVAL="COMPILER=g++-6 && CC=gcc-6 && CXX=g++-6"
+        - MATRIX_EVAL="COMPILER=g++-6 && CC=gcc-6 && CXX=g++-6 && SHARED_LIB_EXT=so"
         - RUN_COVERAGE=true
 
 branches:
@@ -119,7 +120,7 @@ install:
 script:
   - mkdir build && cd build
   - export HELICS_DEPENDENCY_FLAGS="-DZeroMQ_INSTALL_PATH=${TRAVIS_BUILD_DIR}/dependencies/zmq -DBOOST_ROOT=${TRAVIS_BUILD_DIR}/dependencies/boost"
-  - export HELICS_OPTION_FLAGS="-DBUILD_C_SHARED_LIB=ON -DBUILD_HELICS_EXAMPLES=ON -DBUILD_PYTHON=ON -DTRAVIS_TESTS_ENABLE=ON -DPYTHON_LIBRARY=$(python3-config --prefix)/lib/libpython3.6m.so -DPYTHON_INCLUDE_DIR=$(python3-config --prefix)/include/python3.6m/"
+  - export HELICS_OPTION_FLAGS="-DBUILD_C_SHARED_LIB=ON -DBUILD_HELICS_EXAMPLES=ON -DBUILD_PYTHON=ON -DTRAVIS_TESTS_ENABLE=ON -DPYTHON_LIBRARY=$(python3-config --prefix)/lib/libpython3.6m.${SHARED_LIB_EXT} -DPYTHON_INCLUDE_DIR=$(python3-config --prefix)/include/python3.6m/"
   - cmake .. ${HELICS_DEPENDENCY_FLAGS} ${HELICS_OPTION_FLAGS}
   - make -j2
   # For controlling which tests get run:

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -29,7 +29,7 @@ if [[ $commit_msg == *'[update_cache]'* ]]; then
         rm -rf dependencies/zmq;
         individual="true"
     fi
-    
+
     # If no dependency named in commit message, update entire cache
     if [[ "$individual" != 'true' ]]; then
         rm -rf dependencies;
@@ -104,3 +104,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
 elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     export DYLD_FALLBACK_LIBRARY_PATH=${PWD}/dependencies/zmq/lib:${PWD}/dependencies/boost/lib:$LD_LIBRARY_PATH
 fi
+
+pyenv global 3.6.3
+python3 -m pip install --user --upgrade pip wheel
+python3 -m pip install --user --upgrade pytest

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -107,10 +107,14 @@ elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
 fi
 
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-    brew install pyenv
-    pyenv install 3.6.3
+    # HOMEBREW_NO_AUTO_UPDATE=1 brew install boost
+    brew update
+    brew install python3
+    pip3 install pytest
+else
+    pyenv global 3.6.3
+    python3 -m pip install --user --upgrade pip wheel
+    python3 -m pip install --user --upgrade pytest
 fi
 
-pyenv global 3.6.3
-python3 -m pip install --user --upgrade pip wheel
-python3 -m pip install --user --upgrade pytest
+

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -46,7 +46,7 @@ install_boost () {
     IFS='.' read -r -a ver <<< $1
     local boost_version=$1
     local boost_version_str=boost_${ver[0]}_${ver[1]}_${ver[2]}
-    wget -O ${boost_version_str}.tar.gz http://sourceforge.net/projects/boost/files/boost/${boost_version}/${boost_version_str}.tar.gz/download && tar xzf ${boost_version_str}.tar.gz
+    wget --no-check-certificate -O ${boost_version_str}.tar.gz http://sourceforge.net/projects/boost/files/boost/${boost_version}/${boost_version_str}.tar.gz/download && tar xzf ${boost_version_str}.tar.gz
     (
         cd ${boost_version_str}/;
         ./bootstrap.sh --with-libraries=date_time,filesystem,program_options,system,test;
@@ -96,6 +96,7 @@ if [[ ! -d "dependencies/boost" ]]; then
     fi
     echo "*** built boost successfully"
 fi
+
 export BOOST_ROOT=${TRAVIS_BUILD_DIR}/dependencies/boost}
 
 if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -105,6 +105,11 @@ elif [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
     export DYLD_FALLBACK_LIBRARY_PATH=${PWD}/dependencies/zmq/lib:${PWD}/dependencies/boost/lib:$LD_LIBRARY_PATH
 fi
 
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+    brew install pyenv
+    pyenv install 3.6.3
+fi
+
 pyenv global 3.6.3
 python3 -m pip install --user --upgrade pip wheel
 python3 -m pip install --user --upgrade pytest

--- a/tests/python_helics/test_helics.py
+++ b/tests/python_helics/test_helics.py
@@ -1,0 +1,8 @@
+
+def test_import():
+    import helics
+
+def test_version():
+    import helics as h
+    h.helicsGetVersion()
+

--- a/tests/python_helics/test_helics.py
+++ b/tests/python_helics/test_helics.py
@@ -4,5 +4,5 @@ def test_import():
 
 def test_version():
     import helics as h
-    h.helicsGetVersion()
+    print(h.helicsGetVersion())
 


### PR DESCRIPTION
- Imports helics extension on Travis in Python: `import helics`
- Runs the version number of HELICS function in Python: `helics.helicsGetVersion()`