### PR TITLE
Filters addOperation() missing reroute

### DIFF
--- a/src/helics/application_api/Filters.cpp
+++ b/src/helics/application_api/Filters.cpp
@@ -78,7 +78,7 @@ void addOperations (Filter *filt, defined_filter_types type, Core *cptr)
     break;
     case defined_filter_types::reroute:
     {
-        auto op = std::make_shared<RandomDropFilterOperation> ();
+        auto op = std::make_shared<RerouteFilterOperation> ();
         filt->setFilterOperations (std::move (op));
     }
     break;


### PR DESCRIPTION
@phlptp I did this as a pull request because I was just reading the code and saw this copy/paste bug and wanted to make sure it was correct before committing.