### PR TITLE
Thread safety improvements (#180)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,9 @@ project (HELICS)
 set (HELICS_VERSION_MAJOR 1)
 set (HELICS_VERSION_MINOR 0)
 set (HELICS_VERSION_PATCH 0)
-set (HELICS_VERSION_BUILD beta)
-set (HELICS_DATE "02-23-18")
-set (HELICS_VERSION_STRING "1.0.0-beta (02-23-18)")
+set (HELICS_VERSION_BUILD beta.1)
+set (HELICS_DATE "02-26-18")
+set (HELICS_VERSION_STRING "1.0.0-beta.1 ${HELICS_DATE}")
 
 OPTION(BUILD_HELICS_TESTS "Enable the test Executables to be built" ON)
 # enable testing
@@ -103,7 +103,7 @@ IF(UNIX)
   # regular way.
   set(Boost_NO_BOOST_CMAKE ON)
   set(Boost_USE_MULTITHREADED      OFF)   # Needed if MT libraries not built
-  option (USE_BOOST_STATIC_LIBS "Build using boost static Libraries" OFF)
+   option (USE_BOOST_STATIC_LIBS "Build using boost static Libraries" OFF)
 ELSE(UNIX)
   IF(MINGW)
   option (USE_BOOST_STATIC_LIBS "Build using boost static Libraries" OFF)

--- a/ThirdParty/libguarded/ordered_guarded.hpp
+++ b/ThirdParty/libguarded/ordered_guarded.hpp
@@ -19,7 +19,7 @@ This software was modified by Pacific Northwest National Laboratory, operated by
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
 
-additions include load store operations
+additions include load store operations and template specialization for std::mutex and std::timed_mutex
 */
 
 #ifndef LIBGUARDED_ORDERED_GUARDED_HPP

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 shallow_clone: true
 
-version: 1.0.0.beta.{build}
+version: 1.0.0.beta.1.{build}
 
 image: Visual Studio 2015
 
@@ -39,6 +39,6 @@ test_script:
   - ctest -C Release --verbose --timeout 120 -I 0,0,0,1
   - ctest -C Release --verbose --timeout 90 -I 0,0,0,2
   - ctest -C Release --verbose --timeout 240 -I 0,0,0,3
-  #- ctest -C Release --verbose --timeout 90 -I 0,0,0,5
+  - ctest -C Release --verbose --timeout 90 -I 0,0,0,5
 
 artifacts:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,8 @@ def which(program):
         for ext in os.environ.get("PATHEXT", "").split(os.pathsep):
             yield fpath + ext
 
-    fpath, fname = os.path.split(program)
+    #fpath, fname = os.path.split(program)
+    fpath=os.path.dirname(program)
     if fpath:
         if is_exe(program):
             return program

--- a/examples/CInterface/hello_world/hello_world_receiver.c
+++ b/examples/CInterface/hello_world/hello_world_receiver.c
@@ -19,7 +19,7 @@ int main ()
     helics_time_t currenttime = 0.0; /* the current time of the simulation*/
     helics_status  status;/* the result code from a call to the helics Library*/
     helics_bool_t isUpdated;  /* storage for a check if a value has been updated*/
-    char value[128] = ""; /**space to store the sent value*/
+    
 
     /** create an info structure to define some parameters used in federate creation*/
     fedinfo = helicsFederateInfoCreate ();
@@ -67,6 +67,7 @@ int main ()
     isUpdated = helicsSubscriptionIsUpdated (sub);
     if (isUpdated)
     { /* get the value*/
+        char value[128] = ""; /**space to store the sent value*/
         helicsSubscriptionGetString(sub, value, 128);
         printf("%s\n", value);
     }

--- a/examples/CInterface/nonlings_fed1.c
+++ b/examples/CInterface/nonlings_fed1.c
@@ -5,7 +5,6 @@ All rights reserved.
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 
 /* 
@@ -25,10 +24,11 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 */
 void run_sim1(double y,double tol,double *xout,int *converged)
 {
-  double J1, x = *xout;
+  double x = *xout;
   int newt_conv = 0, max_iter = 10, iter = 0;
   /* Solve the equation using Newton */
   while (!newt_conv && iter < max_iter) {
+      double J1;
     /* Function value */
     double f1 = x * x - 2 * x - y + 0.5;
 

--- a/examples/CInterface/nonlings_fed2.c
+++ b/examples/CInterface/nonlings_fed2.c
@@ -1,12 +1,10 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 
 /* Example form http://mathfaculty.fullerton.edu/mathews//n2003/newtonsystem/newtonsystemproof.pdf
@@ -22,13 +20,14 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 */
 void run_sim2(double x,double tol,double *yout,int *converged)
 {
-  double f2,J2,y=*yout;
+  double y=*yout;
   int    newt_conv = 0, max_iter=10,iter=0;
 
   /* Solve the equation using Newton */
   while(!newt_conv && iter < max_iter) {
+      double J2;
     /* Function value */
-    f2 = x*x + 4*y*y - 4;
+    double f2 = x*x + 4*y*y - 4;
 
     /* Convergence check */
     if(fabs(f2) < tol) {
@@ -59,8 +58,8 @@ int main()
   helics_publication  pub;
   int converged;
   char sendbuf[100],recvbuf[100];
-  double y = 1.0, x = 0, /*xprv = 100,*/ yprv=100;
-  int global_conv=0,my_conv=0,other_conv; /* Global and local convergence */
+  double y = 1.0, /*xprv = 100,*/ yprv=100;
+  int my_conv=0,other_conv; /* Global and local convergence */
   helics_time_t currenttime=0.0;
   helics_iteration_status currenttimeiter=iterating;
   double tol=1E-8;
@@ -101,6 +100,10 @@ int main()
 
   /* Enter initialization mode */
   status = helicsFederateEnterInitializationMode(vfed);
+  if (status != helics_ok) {
+      printf("Error entering Initialization\n");
+      return(-1);
+  }
   printf(" Entered initialization mode\n");
 
   snprintf(sendbuf,100,"%18.16f,%d",y,my_conv);
@@ -115,7 +118,9 @@ int main()
 
   fflush(NULL);
 
-  while (currenttimeiter==iterating) {    
+  while (currenttimeiter==iterating) { 
+      int global_conv = 0;
+      double x = 0.0;
     helicsSubscriptionGetString(sub,recvbuf,100);
     sscanf(recvbuf,"%lf,%d",&x,&other_conv);
 

--- a/examples/CInterface/pi_receiver.c
+++ b/examples/CInterface/pi_receiver.c
@@ -1,12 +1,10 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 static char help[] = " PI RECEIVER: Simple program to demonstrate the usage of HELICS C Interface.\n\
             This example creates a value federate subscribing to the publication \n\
@@ -26,7 +24,6 @@ int main ()
     helics_subscription sub;
     helics_time_t currenttime = 0.0;
     double value = 0.0;
-    int isupdated = 0;
 
     helicsversion = helicsGetVersion ();
 
@@ -81,6 +78,7 @@ int main ()
 
     while (currenttime < 0.20)
     {
+        int isupdated;
         helicsFederateRequestTime (vfed, currenttime, &currenttime);
 
         isupdated = helicsSubscriptionIsUpdated (sub);

--- a/examples/CInterface/pi_receiver2.c
+++ b/examples/CInterface/pi_receiver2.c
@@ -1,12 +1,10 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 static char help[] = "Example to demonstrate the usage of HELICS C Interface with two federates.\n\
             This example implements a loose-coupling protocol to exchange values between two federates. \n\
@@ -29,7 +27,6 @@ int main()
   helics_publication  pub;
   helics_time_t currenttime = 0.0;
   double        value = 0.0;
-  int isupdated = 0;
   double pi = 22.0 / 7.0;
 
   helicsversion = helicsGetVersion();
@@ -92,7 +89,7 @@ int main()
 
   while(currenttime < 0.2) {
     
-    isupdated = 0;
+     int isupdated = 0;
     while(!isupdated) {
       helicsFederateRequestTime(vfed,currenttime, &currenttime);
       isupdated = helicsSubscriptionIsUpdated(sub);

--- a/examples/CInterface/pi_sender.c
+++ b/examples/CInterface/pi_sender.c
@@ -34,7 +34,7 @@ int main()
   double         deltat=0.01;
   helics_federate vfed;
   helics_publication pub;
-  double value = 22.0 / 7.0, val;
+  double value = 22.0 / 7.0;
   helics_time_t currenttime = 0.0;
   int           numsteps = 20, i;
 
@@ -94,7 +94,7 @@ int main()
   
 
   for(i=0; i < numsteps; i++) {
-    val = currenttime*value;
+    double val = currenttime*value;
 
     printf("PI SENDER: Sending value %3.2fpi = %4.3f at time %3.2f to PI RECEIVER\n",deltat*i,val,currenttime);
     helicsPublicationPublishDouble(pub,val);

--- a/examples/CInterface/pi_sender2.c
+++ b/examples/CInterface/pi_sender2.c
@@ -1,12 +1,10 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 static char help[] = "Example to demonstrate the usage of HELICS C Interface with two federates.\n\
             This example implements a loose-coupling protocol to exchange values between two federates. \n\
@@ -39,7 +37,6 @@ int main()
   /* This federate will be publishing deltat*pi for numsteps steps */
   double pi = 22.0 / 7.0, value;
   helics_time_t currenttime = 0.0;
-  int  isupdated;
 
   helicsversion = helicsGetVersion();
 
@@ -100,12 +97,12 @@ int main()
   printf("PI SENDER: Entered execution mode\n");
 
   while(currenttime < 0.2) {
+      int  isupdated = 0;
     value = currenttime*pi;
 
     printf("PI SENDER: Sending value %3.2f*pi = %4.3f at time %3.2f to PI RECEIVER\n",currenttime,value,currenttime);
      helicsPublicationPublishDouble(pub,value); /* Note: the receiver will get this at currenttime+deltat */
 
-    isupdated = 0;
     while(!isupdated) {
       helicsFederateRequestTime(vfed,currenttime, &currenttime);
       isupdated = helicsSubscriptionIsUpdated(sub);

--- a/examples/CppInterface/nonlings_fed2.cpp
+++ b/examples/CppInterface/nonlings_fed2.cpp
@@ -54,7 +54,7 @@ int main(int /*argc*/,char ** /*argv*/)
   /* Enter initialization state */
   vfed->enterInitializationState(); // can throw helics::InvalidStateTransition exception
   printf(" Entered initialization state\n");
-  double y = 1.0, x = 0, /*xprv = 100,*/yprv=100;
+  double y = 1.0, /*xprv = 100,*/yprv=100;
 
   vfed->publish(pub, y);
   fflush(NULL);
@@ -74,15 +74,14 @@ int main(int /*argc*/,char ** /*argv*/)
   {
 
 //    xprv = x;
-    x = vfed->getDouble(sub);
+    double x = vfed->getDouble(sub);
     ++helics_iter;
-    double f2,J2;
     int    newt_conv = 0, max_iter=10,iter=0;
 
     /* Solve the equation using Newton */
     while(!newt_conv && iter < max_iter) {
       /* Function value */
-      f2 = x*x + 4*y*y - 4;
+      double f2 = x*x + 4*y*y - 4;
       
       if(fabs(f2) < tol) {
 	newt_conv = 1;
@@ -91,7 +90,7 @@ int main(int /*argc*/,char ** /*argv*/)
       iter++;
 
       /* Jacobian */
-      J2 = 8*y;
+      double J2 = 8*y;
       
       y = y - f2/J2;
     }

--- a/examples/CppInterface/pi_receiver.cpp
+++ b/examples/CppInterface/pi_receiver.cpp
@@ -15,7 +15,6 @@ static char help[] = " PI RECEIVER: Simple program to demonstrate the usage of H
 #include <stdio.h>
 #include <cpp98/ValueFederate.hpp>
 #include <cpp98/helics.hpp>
-#include "core/helicsVersion.hpp"
 
 int main(int /*argc*/,char ** /*argv*/)
 {
@@ -24,7 +23,7 @@ int main(int /*argc*/,char ** /*argv*/)
   helics_subscription sub;
 
 
-  std::string helicsversion = helics::versionString();
+  std::string helicsversion = helics::getHelicsVersionString();
 
   printf("PI RECEIVER: Helics version = %s\n",helicsversion.c_str());
   printf("%s",help);

--- a/examples/CppInterface/pi_receiver2.cpp
+++ b/examples/CppInterface/pi_receiver2.cpp
@@ -9,13 +9,12 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 
 static char help[] = "Example to demonstrate the usage of HELICS C Interface with two federates.\n\
             This example implements a loose-coupling protocol to exchange values between two federates. \n\
-            Here, a value federate, that can both publish and subcribe is created.\n\
+            Here, a value federate, that can both publish and subscribe is created.\n\
             This federate can only publish a value once it receives value from the other federate.\n\n";
 
 #include <stdio.h>
 #include <cpp98/ValueFederate.hpp>
 #include <cpp98/helics.hpp> // helicsVersionString
-#include "core/helicsVersion.hpp"
 #include <math.h>
 
 int main(int /*argc*/,char ** /*argv*/)
@@ -25,10 +24,7 @@ int main(int /*argc*/,char ** /*argv*/)
   helics_subscription sub;
   helics_publication  pub;
 
-
-  std::string helicsversion = helics::versionString();
-
-  printf("PI RECEIVER: Helics version = %s\n",helicsversion.c_str());
+  printf("PI RECEIVER: Helics version = %s\n", helicsGetVersion());
   printf("%s",help);
 
   /* Create Federate Info object that describes the federate properties

--- a/examples/CppInterface/pi_sender.cpp
+++ b/examples/CppInterface/pi_sender.cpp
@@ -78,12 +78,12 @@ int main(int /*argc*/,char ** /*argv*/)
 
   /* This federate will be publishing deltat*pi for numsteps steps */
   //double this_time = 0.0;
-  double value = 22.0/7.0,val;
+  double value = 22.0/7.0;
   helics_time_t currenttime=0.0;
   int           numsteps=20,i;
 
   for(i=0; i < numsteps; i++) {
-    val = currenttime*value;
+    double val = currenttime*value;
 
     printf("PI SENDER: Sending value %3.2fpi = %4.3f at time %3.2f to PI RECEIVER\n",deltat*i,val,currenttime);
     vfed->publish(pub, val);

--- a/src/helics/application_api/FederateInfo.cpp
+++ b/src/helics/application_api/FederateInfo.cpp
@@ -47,7 +47,7 @@ void FederateInfo::loadInfoFromArgs (int argc, const char *const *argv)
     auto res = argumentParser (argc, argv, vm, InfoArgs);
     if (res == versionReturn)
     {
-        std::cout << helics::versionString () << '\n';
+        std::cout << helics::versionString << '\n';
     }
     if (res < 0)
     {

--- a/src/helics/application_api/MessageFederateManager.hpp
+++ b/src/helics/application_api/MessageFederateManager.hpp
@@ -146,9 +146,9 @@ class MessageFederateManager
 
     std::map<Core::handle_id_t, std::pair<endpoint_id_t, std::string>> subHandleLookup;  //!< map for subscriptions
     Time CurrentTime;  //!< the current simulation time
-    Core *coreObject;  //!< the pointer to the actual core
+    Core * coreObject;  //!< the pointer to the actual core
     std::atomic<endpoint_id_t::underlyingType> endpointCount{0};  //!< the count of actual endpoints
-    Core::federate_id_t fedID;  //!< storage for the federate ID
+    const Core::federate_id_t fedID;  //!< storage for the federate ID
     mutable std::mutex endpointLock;  //!< lock for protecting the endpoint list
     std::vector<SimpleQueue<std::unique_ptr<Message>>> messageQueues;  //!< the storage for the message queues
     guarded<std::vector<unsigned int>> messageOrder;  //!< maintaining a list of the ordered messages

--- a/src/helics/application_api/MessageOperators.hpp
+++ b/src/helics/application_api/MessageOperators.hpp
@@ -97,7 +97,7 @@ class CloneOperator : public FilterOperator
     /** default constructor*/
     CloneOperator () = default;
     /** set the function to modify the data of the message in the constructor*/
-    CloneOperator (std::function<void(const Message *)> userCloneFunction);
+    explicit CloneOperator (std::function<void(const Message *)> userCloneFunction);
     /** set the function to modify the data of the message*/
     void setCloneFunction (std::function<void(const Message *)> userCloneFunction);
 

--- a/src/helics/application_api/Subscriptions.hpp
+++ b/src/helics/application_api/Subscriptions.hpp
@@ -357,7 +357,7 @@ class VectorSubscription
 {
   private:
     ValueFederate *fed = nullptr;  //!< reference to the value federate
-    std::string m_name;  //!< the name of the subscription
+    std::string m_key;  //!< the key for the subscription
     std::string m_units;  //!< the defined units of the federate
     std::vector<subscription_id_t> ids;  //!< the id of the federate
     std::function<void(int, Time)> update_callback;  //!< callback function for when a value is updated
@@ -368,18 +368,21 @@ class VectorSubscription
     /**constructor to build a subscription object
     @param[in] required a flag indicating that the subscription is required to have a matching publication
     @param[in] valueFed  the ValueFederate to use
-    @param[in] name the name of the subscription
-    @param[in] units the units associated with a Federate
+    @param[in] key the identifier for the publication to subscribe to
+    @param[in] startIndex the index to start with
+    @param[in] count the number of values to subscribe to
+    @param[in] defValue the default value
+    @param[in] units the units associated with the Subscription
     */
     template<class FedPtr>
     VectorSubscription (interface_availability required,
                         FedPtr valueFed,
-                        std::string name,
+                        const std::string &key,
                         int startIndex,
                         int count,
                         const X &defValue,
                         const std::string &units = std::string())
-        : fed (std::addressof(*valueFed)), m_name (std::move (name)), m_units (units)
+        : fed (std::addressof(*valueFed)), m_key (key), m_units (units)
     {
         static_assert(std::is_base_of<ValueFederate, std::remove_reference_t<decltype(*valueFed)>>::value, "first argument must be a pointer to a ValueFederate");
         ids.reserve (count);
@@ -388,7 +391,7 @@ class VectorSubscription
         {
             for (auto ind = startIndex; ind < startIndex + count; ++ind)
             {
-                auto id = fed->registerRequiredSubscription<X> (m_name, ind, m_units);
+                auto id = fed->registerRequiredSubscription<X> (m_key, ind, m_units);
                 ids.push_back (id);
             }
         }
@@ -396,7 +399,7 @@ class VectorSubscription
         {
             for (auto ind = startIndex; ind < startIndex + count; ++ind)
             {
-                auto id = fed->registerOptionalSubscription<X> (m_name, ind, m_units);
+                auto id = fed->registerOptionalSubscription<X> (m_key, ind, m_units);
                 ids.push_back (id);
             }
         }
@@ -406,22 +409,25 @@ class VectorSubscription
     }
     /**constructor to build a subscription object
     @param[in] valueFed  the ValueFederate to use
-    @param[in] name the name of the subscription
-    @param[in] units the units associated with a Federate
+    @param[in] key the identifier for the publication to subscribe to
+    @param[in] startIndex the index to start with
+    @param[in] count the number of values to subscribe to
+    @param[in] defValue the default value
+    @param[in] units the units associated with the Subscription
     */
     template<class FedPtr>
     VectorSubscription (FedPtr valueFed,
-                        std::string name,
+                        const std::string &key,
                         int startIndex,
                         int count,
                         const X &defValue,
                         const std::string &units = std::string())
-        : VectorSubscription (false, valueFed, name, startIndex, count, defValue, units)
+        : VectorSubscription (false, valueFed, key, startIndex, count, defValue, units)
     {
     }
     /** move constructor*/
     VectorSubscription (VectorSubscription &&vs) noexcept
-        : fed (vs.fed), m_name (std::move (vs.m_name)), m_units (std::move (vs.m_units)), ids (std::move (vs.ids)),
+        : fed (vs.fed), m_key (std::move (vs.m_key)), m_units (std::move (vs.m_units)), ids (std::move (vs.ids)),
           update_callback (std::move (vs.update_callback)), vals (std::move (vs.vals))
     {
         // need to transfer the callback to the new object
@@ -433,7 +439,7 @@ class VectorSubscription
     VectorSubscription &operator= (VectorSubscription &&vs) noexcept
     {
         fed = vs.fed;
-        m_name = std::move (vs.m_name);
+        m_key = std::move (vs.m_key);
         m_units = std::move (vs.m_units);
         ids = std::move (vs.ids);
         update_callback = std::move (vs.update_callback);
@@ -480,7 +486,7 @@ class VectorSubscription2d
 {
   private:
     ValueFederate *fed = nullptr;  //!< reference to the value federate
-    std::string m_name;  //!< the name of the subscription
+    std::string m_key;  //!< the name of the subscription
     std::string m_units;  //!< the defined units of the federate
     std::vector<subscription_id_t> ids;  //!< the id of the federate
     std::function<void(int, Time)> update_callback;  //!< callback function for when a value is updated
@@ -492,20 +498,25 @@ class VectorSubscription2d
     /**constructor to build a subscription object
     @param[in] required a flag indicating that the subscription is required to have a matching publication
     @param[in] valueFed  the ValueFederate to use
-    @param[in] name the name of the subscription
-    @param[in] units the units associated with a Federate
+     @param[in] key the identifier for the publication to subscribe to
+    @param[in] startIndex_x the index to start with in the x dimension
+    @param[in] count_x the number of values in the x direction
+    @param[in] startIndex_y the index to start with in the x dimension
+    @param[in] count_y the number of values in the x direction
+    @param[in] defValue the default value
+    @param[in] units the units associated with the Subscription
     */
     template<class FedPtr>
     VectorSubscription2d(interface_availability required,
         FedPtr valueFed,
-        std::string name,
+        const std::string &key,
         int startIndex_x,
         int count_x,
         int startIndex_y,
         int count_y,
         const X &defValue,
         const std::string &units = std::string())
-        : fed (std::addressof(*valueFed)), m_name (std::move (name)), m_units (units)
+        : fed (std::addressof(*valueFed)), m_key (key), m_units (units)
     {
         static_assert(std::is_base_of<ValueFederate, std::remove_reference_t<decltype(*valueFed)>>::value, "Second argument must be a pointer to a ValueFederate");
         ids.reserve (count_x * count_y);
@@ -516,7 +527,7 @@ class VectorSubscription2d
             {
                 for (auto ind_y = startIndex_y; ind_y < startIndex_y + count_y; ++ind_y)
                 {
-                    auto id = fed->registerRequiredSubscriptionIndexed<X> (m_name, ind_x, ind_y, m_units);
+                    auto id = fed->registerRequiredSubscriptionIndexed<X> (m_key, ind_x, ind_y, m_units);
                     ids.push_back (id);
                 }
             }
@@ -527,7 +538,7 @@ class VectorSubscription2d
             {
                 for (auto ind_y = startIndex_y; ind_y < startIndex_y + count_y; ++ind_y)
                 {
-                    auto id = fed->registerOptionalSubscriptionIndexed<X> (m_name, ind_x, ind_y, m_units);
+                    auto id = fed->registerOptionalSubscriptionIndexed<X> (m_key, ind_x, ind_y, m_units);
                     ids.push_back (id);
                 }
             }
@@ -543,12 +554,17 @@ class VectorSubscription2d
 
     /**constructor to build a subscription object
     @param[in] valueFed  the ValueFederate to use
-    @param[in] name the name of the subscription
-    @param[in] units the units associated with a Federate
+    @param[in] key the identifier for the publication to subscribe to
+    @param[in] startIndex_x the index to start with in the x dimension
+    @param[in] count_x the number of values in the x direction
+    @param[in] startIndex_y the index to start with in the x dimension
+    @param[in] count_y the number of values in the x direction
+    @param[in] defValue the default value
+    @param[in] units the units associated with the Subscription
     */
     template<class FedPtr>
     VectorSubscription2d(FedPtr valueFed,
-        const std::string &name,
+        const std::string &key,
         int startIndex_x,
         int count_x,
         int startIndex_y,
@@ -557,7 +573,7 @@ class VectorSubscription2d
         const std::string &units = std::string())
         : VectorSubscription2d(interface_availability::optional,
                                 valueFed,
-                                name,
+                                key,
                                 startIndex_x,
                                 count_x,
                                 startIndex_y,
@@ -568,10 +584,9 @@ class VectorSubscription2d
     }
     /** move constructor*/
     VectorSubscription2d (VectorSubscription2d &&vs) noexcept
-        : fed (vs.fed), m_name (std::move (vs.m_name)), m_units (std::move (vs.m_units)), ids (std::move (vs.ids)),
-          update_callback (std::move (vs.update_callback)), vals (std::move (vs.vals))
+        : fed (vs.fed), m_key (std::move (vs.m_key)), m_units (std::move (vs.m_units)), ids (std::move (vs.ids)),
+          update_callback (std::move (vs.update_callback)), vals (std::move (vs.vals)),indices(vs.indices)
     {
-        indices = vs.indices;
         // need to transfer the callback to the new object
         fed->registerSubscriptionNotificationCallback (ids, [this](subscription_id_t id, Time tm) {
             handleCallback (id, tm);
@@ -582,7 +597,7 @@ class VectorSubscription2d
     VectorSubscription2d &operator= (VectorSubscription2d &&vs) noexcept
     {
         fed = vs.fed;
-        m_name = std::move (vs.m_name);
+        m_key = std::move (vs.m_key);
         m_units = std::move (vs.m_units);
         ids = std::move (vs.ids);
         update_callback = std::move (vs.update_callback);

--- a/src/helics/application_api/ValueFederateManager.hpp
+++ b/src/helics/application_api/ValueFederateManager.hpp
@@ -1,15 +1,12 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
-#ifndef _VALUE_FEDERATE_MANAGER_H_
-#define _VALUE_FEDERATE_MANAGER_H_
+
 #pragma once
 
 #include "../core/Core.hpp"
@@ -24,6 +21,7 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 #include <utility>
 #include "../common/DualMappedVector.hpp"
 #include "../common/MappedVector.hpp"
+#include <atomic>
 
 namespace helics
 {
@@ -94,7 +92,7 @@ class ValueFederateManager
 		@param[in] id the subscription identifier
 		@param[in] block the data block representing the default value
 		*/
-    void setDefaultValue (subscription_id_t id, data_view block);
+    void setDefaultValue (subscription_id_t id, const data_view &block);
 
 		/** get a value as raw data block from the system
 		@param[in] id the identifier for the subscription
@@ -103,7 +101,7 @@ class ValueFederateManager
     data_view getValue (subscription_id_t id);
 
 		/** publish a value*/
-    void publish (publication_id_t id, data_view block);
+    void publish (publication_id_t id, const data_view &block);
 
 		/** check if a given subscription has and update*/
     bool queryUpdate (subscription_id_t sub_id) const;
@@ -193,11 +191,13 @@ class ValueFederateManager
 	private:
 		DualMappedVector<subscription_info,std::string,Core::handle_id_t> subscriptions; 
 		MappedVector<publication_info> publications;
+        std::atomic<publication_id_t::underlyingType> publicationCount{ 0 };  //!< the count of actual endpoints
     std::vector<std::function<void(subscription_id_t, Time)>> callbacks;  //!< the all callback function
 		std::vector<data_view> lastData;	//!< the last data to arrive
     Time CurrentTime = Time (-1.0);  //!< the current simulation time
 		Core *coreObject; //!< the pointer to the actual core
 		Core::federate_id_t fedID;  //!< the federation ID from the core API
+        std::atomic<subscription_id_t::underlyingType> subscriptionCount{ 0 };  //!< the count of actual endpoints
 		int allCallbackIndex = -1;	//!< index of the allCallback function
 
 		mutable std::mutex subscription_mutex; //!< mutex protecting the subscription information
@@ -207,4 +207,3 @@ class ValueFederateManager
 };
 
 }  // namespace helics
-#endif

--- a/src/helics/application_api/helicsTypes.hpp
+++ b/src/helics/application_api/helicsTypes.hpp
@@ -229,12 +229,16 @@ std::string helicsComplexString (std::complex<double> val);
 std::string helicsVectorString (const std::vector<double> &val);
 std::string helicsVectorString (const double *vals, size_t size);
 std::string helicsComplexVectorString (const std::vector<std::complex<double>> &val);
+std::string helicsNamedPointString(const named_point &point);
+std::string helicsNamedPointString(const std::string &pointName, double val);
 /** convert a string to a complex number*/
 std::complex<double> helicsGetComplex (const std::string &val);
 /** convert a string to a vector*/
 std::vector<double> helicsGetVector (const std::string &val);
 /** convert a string to a complex vector*/
 std::vector<std::complex<double>> helicsGetComplexVector (const std::string &val);
+
+named_point helicsGetNamedPoint(const std::string &val);
 
 void helicsGetVector (const std::string &val, std::vector<double> &data);
 void helicsGetComplexVector (const std::string &val, std::vector<std::complex<double>> &data);

--- a/src/helics/apps/Echo.cpp
+++ b/src/helics/apps/Echo.cpp
@@ -38,7 +38,7 @@ Echo::Echo (int argc, char *argv[])
     auto res = argumentParser(argc, argv, vm_map, InfoArgs,"input");
     if (res == versionReturn)
     {
-        std::cout << helics::versionString() << '\n';
+        std::cout << helics::versionString << '\n';
     }
     if (res < 0)
     {

--- a/src/helics/apps/Player.cpp
+++ b/src/helics/apps/Player.cpp
@@ -60,7 +60,7 @@ Player::Player (int argc, char *argv[])
     auto res = argumentParser(argc, argv, vm_map, InfoArgs,"input");
     if (res == versionReturn)
     {
-        std::cout << helics::versionString() << '\n';
+        std::cout << helics::versionString<< '\n';
     }
     if (res == helpReturn)
     {

--- a/src/helics/apps/Recorder.cpp
+++ b/src/helics/apps/Recorder.cpp
@@ -56,7 +56,7 @@ Recorder::Recorder (int argc, char *argv[])
     auto res = argumentParser(argc, argv, vm_map, InfoArgs, "input");
     if (res == versionReturn)
     {
-        std::cout << helics::versionString() << '\n';
+        std::cout << helics::versionString << '\n';
     }
     if (res == helpReturn)
     {

--- a/src/helics/apps/Source.cpp
+++ b/src/helics/apps/Source.cpp
@@ -42,7 +42,7 @@ Source::Source (int argc, char *argv[])
     auto res = argumentParser(argc, argv, vm_map, InfoArgs, "input"s);
     if (res == versionReturn)
     {
-        std::cout << helics::versionString() << '\n';
+        std::cout << helics::versionString << '\n';
     }
     if (res < 0)
     {

--- a/src/helics/apps/Tracer.cpp
+++ b/src/helics/apps/Tracer.cpp
@@ -57,7 +57,7 @@ Tracer::Tracer (int argc, char *argv[])
     auto res = argumentParser(argc, argv, vm_map, InfoArgs, "input");
     if (res == versionReturn)
     {
-        std::cout << helics::versionString() << '\n';
+        std::cout << helics::versionString << '\n';
     }
     if (res < 0)
     {

--- a/src/helics/apps/appMain.cpp
+++ b/src/helics/apps/appMain.cpp
@@ -58,7 +58,7 @@ int main (int argc, char *argv[])
         }
         else if ((arg1 == "--version")||(arg1=="-v"))
         {
-            std::cout << "helics_app\n" << helics::versionString() << '\n';
+            std::cout << "helics_app\n" << helics::versionString << '\n';
         }
         else if ((arg1 == "--help") || (arg1 == "-?"))
         {

--- a/src/helics/common/AsioServiceManager.cpp
+++ b/src/helics/common/AsioServiceManager.cpp
@@ -125,9 +125,9 @@ AsioServiceManager::~AsioServiceManager ()
     }
 }
 
-AsioServiceManager::AsioServiceManager (const std::string &serviceName) : name (serviceName)
+AsioServiceManager::AsioServiceManager (const std::string &serviceName)
+    : name (serviceName), iserv (std::make_unique<boost::asio::io_service> ())
 {
-    iserv = std::make_unique<boost::asio::io_service> ();
 }
 
 AsioServiceManager::LoopHandle AsioServiceManager::runServiceLoop (const std::string &serviceName)
@@ -200,5 +200,5 @@ void serviceRunLoop (std::shared_ptr<AsioServiceManager> ptr)
         std::cout << "caught other error in service loop" << std::endl;
     }
     // std::cout << "service loop stopped\n";
-    ptr->running.store( false );
+    ptr->running.store (false);
 }

--- a/src/helics/common/logger.h
+++ b/src/helics/common/logger.h
@@ -38,6 +38,7 @@ namespace helics
     class LoggingCore
     {
     private:
+        static std::atomic<bool> fastShutdown; //set to true to enable a fast shutdown
         std::thread loggingThread;	//!< the thread object containing the thread running the actual Logger
         std::vector<std::function<void(std::string &&message)>> functions; //!< container for the functions
         std::mutex functionLock;    //!< lock for updating the functions
@@ -72,6 +73,8 @@ namespace helics
         void haltOperations(int);
         /** update a callback for a particular instance*/
         void updateProcessingFunction(int index, std::function<void(std::string &&message)> newFunction);
+        /** enable a fast shutdown in situations where a thread may be force-ably terminated*/
+        static void setFastShutdown();
     private:
         void processingLoop();
     };
@@ -206,6 +209,7 @@ public:
     static void closeLogger(const std::string &loggerName = "");
    /** sends a message to the default Logger*/
     static void logMessage(const std::string &message);
+    
     /*destructor*/
     virtual ~LoggerManager();
     /** get the name of the logger*/

--- a/src/helics/common/zmqContextManager.cpp
+++ b/src/helics/common/zmqContextManager.cpp
@@ -85,7 +85,7 @@ zmqContextManager::~zmqContextManager ()
     }
 }
 
-zmqContextManager::zmqContextManager (const std::string &contextName) : name (contextName)
+zmqContextManager::zmqContextManager (const std::string &contextName)
+    : name (contextName), zcontext (std::make_unique<zmq::context_t> ())
 {
-    zcontext = std::make_unique<zmq::context_t> ();
 }

--- a/src/helics/core/ActionMessage.cpp
+++ b/src/helics/core/ActionMessage.cpp
@@ -58,9 +58,8 @@ ActionMessage::ActionMessage (const ActionMessage &act)
 
 ActionMessage::ActionMessage (std::unique_ptr<Message> message)
     : messageAction (CMD_SEND_MESSAGE), index (dest_handle), actionTime (message->time),
-      payload (std::move (message->data.m_data)), name (payload)
+      payload (std::move (message->data.m_data)), name (payload), extraInfo(std::make_unique<AdditionalInfo>())
 {
-    extraInfo = std::make_unique<AdditionalInfo> ();
     extraInfo->source = std::move (message->source);
     extraInfo->orig_source = std::move (message->original_source);
     extraInfo->original_dest = std::move (message->original_dest);
@@ -89,7 +88,7 @@ ActionMessage &ActionMessage::operator= (const ActionMessage &act)
     Te = act.Te;
     Tdemin = act.Tdemin;
     payload = act.payload;
-
+    index = act.index;
     if (act.extraInfo)
     {
         extraInfo = std::make_unique<AdditionalInfo> ((*act.extraInfo));
@@ -106,6 +105,7 @@ ActionMessage &ActionMessage::operator= (ActionMessage &&act) noexcept
     dest_handle = act.dest_handle;
     counter = act.counter;
     flags = act.flags;
+    index = act.index;
     actionTime = act.actionTime;
     Te = act.Te;
     Tdemin = act.Tdemin;

--- a/src/helics/core/BrokerFactory.cpp
+++ b/src/helics/core/BrokerFactory.cpp
@@ -44,7 +44,11 @@ std::shared_ptr<Broker> makeBroker (core_type type, const std::string &name)
 #if HELICS_HAVE_ZEROMQ
         type = core_type::ZMQ;
 #else
+#ifndef DISABLE_TCP_CORE
+        type = core_type::TCP;
+#else
         type = core_type::UDP;
+#endif
 #endif
     }
 
@@ -54,11 +58,11 @@ std::shared_ptr<Broker> makeBroker (core_type type, const std::string &name)
 #if HELICS_HAVE_ZEROMQ
         if (name.empty ())
         {
-            broker = std::make_shared<ZmqBroker> ();
+            broker = std::make_shared<zeromq::ZmqBroker> ();
         }
         else
         {
-            broker = std::make_shared<ZmqBroker> (name);
+            broker = std::make_shared<zeromq::ZmqBroker> (name);
         }
 
 #else
@@ -69,11 +73,11 @@ std::shared_ptr<Broker> makeBroker (core_type type, const std::string &name)
 #if HELICS_HAVE_MPI
         if (name.empty ())
         {
-            broker = std::make_shared<MpiBroker> ();
+            broker = std::make_shared<mpi::MpiBroker> ();
         }
         else
         {
-            broker = std::make_shared<MpiBroker> (name);
+            broker = std::make_shared<mpi::MpiBroker> (name);
         }
 #else
         throw (HelicsException ("mpi broker type is not available"));
@@ -82,43 +86,43 @@ std::shared_ptr<Broker> makeBroker (core_type type, const std::string &name)
     case core_type::TEST:
         if (name.empty ())
         {
-            broker = std::make_shared<TestBroker> ();
+            broker = std::make_shared<testcore::TestBroker> ();
         }
         else
         {
-            broker = std::make_shared<TestBroker> (name);
+            broker = std::make_shared<testcore::TestBroker> (name);
         }
         break;
     case core_type::INTERPROCESS:
     case core_type::IPC:
         if (name.empty ())
         {
-            broker = std::make_shared<IpcBroker> ();
+            broker = std::make_shared<ipc::IpcBroker> ();
         }
         else
         {
-            broker = std::make_shared<IpcBroker> (name);
+            broker = std::make_shared<ipc::IpcBroker> (name);
         }
         break;
     case core_type::UDP:
         if (name.empty ())
         {
-            broker = std::make_shared<UdpBroker> ();
+            broker = std::make_shared<udp::UdpBroker> ();
         }
         else
         {
-            broker = std::make_shared<UdpBroker> (name);
+            broker = std::make_shared<udp::UdpBroker> (name);
         }
         break;
     case core_type::TCP:
 #ifndef DISABLE_TCP_CORE
         if (name.empty ())
         {
-            broker = std::make_shared<TcpBroker> ();
+            broker = std::make_shared<tcp::TcpBroker> ();
         }
         else
         {
-            broker = std::make_shared<TcpBroker> (name);
+            broker = std::make_shared<tcp::TcpBroker> (name);
         }
 #else
         throw (HelicsException ("tcp broker type is not available"));
@@ -172,6 +176,7 @@ std::shared_ptr<Broker> create (core_type type, const std::string &broker_name, 
     if (!reg)
     {
     }
+    broker->connect();
     return broker;
 }
 
@@ -240,37 +245,43 @@ void displayHelp (core_type type)
     {
     case core_type::ZMQ:
 #if HELICS_HAVE_ZEROMQ
-        ZmqBroker::displayHelp (true);
+        zeromq::ZmqBroker::displayHelp (true);
 #endif
         break;
     case core_type::MPI:
 #if HELICS_HAVE_MPI
-        MpiBroker::displayHelp (true);
+        mpi::MpiBroker::displayHelp (true);
 #endif
         break;
     case core_type::TEST:
-        TestBroker::displayHelp (true);
+        testcore::TestBroker::displayHelp (true);
         break;
     case core_type::INTERPROCESS:
     case core_type::IPC:
-        IpcBroker::displayHelp (true);
+        ipc::IpcBroker::displayHelp (true);
         break;
     case core_type::TCP:
+#ifndef DISABLE_TCP_CORE
+       tcp::TcpBroker::displayHelp(true);
+#endif
         break;
     case core_type::UDP:
-        UdpBroker::displayHelp (true);
+        udp::UdpBroker::displayHelp (true);
         break;
     default:
 #if HELICS_HAVE_ZEROMQ
-        ZmqBroker::displayHelp (true);
+        zeromq::ZmqBroker::displayHelp (true);
 #endif
 #if HELICS_HAVE_MPI
-        MpiBroker::displayHelp (true);
+        mpi::MpiBroker::displayHelp (true);
 #endif
-        IpcBroker::displayHelp (true);
+        ipc::IpcBroker::displayHelp (true);
 
-        TestBroker::displayHelp (true);
-        UdpBroker::displayHelp (true);
+        testcore::TestBroker::displayHelp (true);
+#ifndef DISABLE_TCP_CORE
+        tcp::TcpBroker::displayHelp(true);
+#endif
+        udp::UdpBroker::displayHelp (true);
         break;
     }
 

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -1433,8 +1433,16 @@ void CommonCore::deliverMessage (ActionMessage &message)
             auto ffunc = getFilterCoordinator (localP->id);
 
             auto tempMessage = createMessageFromCommand (std::move (message));
-            auto nmessage = ffunc->destFilter->filterOp->process (std::move (tempMessage));
-            message.moveInfo (std::move (nmessage));
+            if (ffunc->destFilter->filterOp)
+            {
+                auto nmessage = ffunc->destFilter->filterOp->process(std::move(tempMessage));
+                message.moveInfo(std::move(nmessage));
+            }
+            else
+            {
+                message.moveInfo(std::move(tempMessage));
+            }
+            
         }
         message.dest_id = localP->fed_id;
         message.dest_handle = localP->id;

--- a/src/helics/core/CommsBroker.cpp
+++ b/src/helics/core/CommsBroker.cpp
@@ -1,12 +1,10 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 
 #include "CommsBroker.hpp"
@@ -29,20 +27,20 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 
 namespace helics
 {
-template class CommsBroker<IpcComms, CoreBroker>;
-template class CommsBroker<IpcComms, CommonCore>;
-template class CommsBroker<ZmqComms, CoreBroker>;
-template class CommsBroker<ZmqComms, CommonCore>;
-template class CommsBroker<UdpComms, CoreBroker>;
-template class CommsBroker<UdpComms, CommonCore>;
+template class CommsBroker<ipc::IpcComms, CoreBroker>;
+template class CommsBroker<ipc::IpcComms, CommonCore>;
+template class CommsBroker<zeromq::ZmqComms, CoreBroker>;
+template class CommsBroker<zeromq::ZmqComms, CommonCore>;
+template class CommsBroker<udp::UdpComms, CoreBroker>;
+template class CommsBroker<udp::UdpComms, CommonCore>;
 
 #ifndef DISABLE_TCP_CORE
-template class CommsBroker<TcpComms, CommonCore>;
-template class CommsBroker<TcpComms, CoreBroker>;
+template class CommsBroker<tcp::TcpComms, CommonCore>;
+template class CommsBroker<tcp::TcpComms, CoreBroker>;
 #endif
 
 #if HELICS_HAVE_MPI
-template class CommsBroker<MpiComms, CoreBroker>;
-template class CommsBroker<MpiComms, CommonCore>;
+template class CommsBroker<mpi::MpiComms, CoreBroker>;
+template class CommsBroker<mpi::MpiComms, CommonCore>;
 #endif
 }  // namespace helics

--- a/src/helics/core/CoreFactory.cpp
+++ b/src/helics/core/CoreFactory.cpp
@@ -52,11 +52,11 @@ std::shared_ptr<Core> makeCore (core_type type, const std::string &name)
 #if HELICS_HAVE_ZEROMQ
         if (name.empty ())
         {
-            core = std::make_shared<ZmqCore> ();
+            core = std::make_shared<zeromq::ZmqCore> ();
         }
         else
         {
-            core = std::make_shared<ZmqCore> (name);
+            core = std::make_shared<zeromq::ZmqCore> (name);
         }
 
 #else
@@ -67,11 +67,11 @@ std::shared_ptr<Core> makeCore (core_type type, const std::string &name)
 #if HELICS_HAVE_MPI
         if (name.empty ())
         {
-            core = std::make_shared<MpiCore> ();
+            core = std::make_shared<mpi::MpiCore> ();
         }
         else
         {
-            core = std::make_shared<MpiCore> (name);
+            core = std::make_shared<mpi::MpiCore> (name);
         }
 #else
         throw (HelicsException ("MPI core is not available"));
@@ -80,43 +80,43 @@ std::shared_ptr<Core> makeCore (core_type type, const std::string &name)
     case core_type::TEST:
         if (name.empty ())
         {
-            core = std::make_shared<TestCore> ();
+            core = std::make_shared<testcore::TestCore> ();
         }
         else
         {
-            core = std::make_shared<TestCore> (name);
+            core = std::make_shared<testcore::TestCore> (name);
         }
         break;
     case core_type::INTERPROCESS:
     case core_type::IPC:
         if (name.empty ())
         {
-            core = std::make_shared<IpcCore> ();
+            core = std::make_shared<ipc::IpcCore> ();
         }
         else
         {
-            core = std::make_shared<IpcCore> (name);
+            core = std::make_shared<ipc::IpcCore> (name);
         }
         break;
     case core_type::UDP:
         if (name.empty ())
         {
-            core = std::make_shared<UdpCore> ();
+            core = std::make_shared<udp::UdpCore> ();
         }
         else
         {
-            core = std::make_shared<UdpCore> (name);
+            core = std::make_shared<udp::UdpCore> (name);
         }
         break;
     case core_type::TCP:
 #ifndef DISABLE_TCP_CORE
         if (name.empty ())
         {
-            core = std::make_shared<TcpCore> ();
+            core = std::make_shared<tcp::TcpCore> ();
         }
         else
         {
-            core = std::make_shared<TcpCore> (name);
+            core = std::make_shared<tcp::TcpCore> (name);
         }
 #else
         throw (HelicsException ("TCP core is not available"));
@@ -268,26 +268,26 @@ bool isJoinableCoreOfType (core_type type, const std::shared_ptr<CommonCore> &pt
         {
         case core_type::ZMQ:
 #if HELICS_HAVE_ZEROMQ
-            return (dynamic_cast<ZmqCore *> (ptr.get ()) != nullptr);
+            return (dynamic_cast<zeromq::ZmqCore *> (ptr.get ()) != nullptr);
 #else
             break;
 #endif
         case core_type::MPI:
 #if HELICS_HAVE_MPI
-            return (dynamic_cast<MpiCore *> (ptr.get ()) != nullptr);
+            return (dynamic_cast<mpi::MpiCore *> (ptr.get ()) != nullptr);
 #else
             break;
 #endif
         case core_type::TEST:
-            return (dynamic_cast<TestCore *> (ptr.get ()) != nullptr);
+            return (dynamic_cast<testcore::TestCore *> (ptr.get ()) != nullptr);
         case core_type::INTERPROCESS:
         case core_type::IPC:
-            return (dynamic_cast<IpcCore *> (ptr.get ()) != nullptr);
+            return (dynamic_cast<ipc::IpcCore *> (ptr.get ()) != nullptr);
         case core_type::UDP:
-            return (dynamic_cast<UdpCore *> (ptr.get ()) != nullptr);
+            return (dynamic_cast<udp::UdpCore *> (ptr.get ()) != nullptr);
         case core_type::TCP:
 #ifndef DISABLE_TCP_CORE
-            return (dynamic_cast<TcpCore *> (ptr.get ()) != nullptr);
+            return (dynamic_cast<tcp::TcpCore *> (ptr.get ()) != nullptr);
 #endif
         default:
             return true;

--- a/src/helics/core/CoreFactory.hpp
+++ b/src/helics/core/CoreFactory.hpp
@@ -1,15 +1,12 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
-#ifndef _HELICS_CORE_FACTORY_
-#define _HELICS_CORE_FACTORY_
+
 
 #include "core-types.hpp"
 #include <memory>
@@ -42,7 +39,7 @@ std::shared_ptr<Core> create (core_type type, const std::string &initializationS
 std::shared_ptr<Core> create (core_type type, int argc, const char *const *argv);
 
 /** create a core from arguments
-@details an argument of coretype must be specified to define the type,  otherwise the default type is used
+@details an argument of '--coretype' must be specified to define the type,  otherwise the default type is used
 @param argc the number of arguments
 @param argv the actual argument parameters
 @return a pointer to the created core
@@ -112,5 +109,3 @@ void copyCoreIdentifier (const std::string &copyFromName, const std::string &cop
 }  // namespace CoreFactory
 
 }  // namespace helics
-
-#endif

--- a/src/helics/core/EndpointInfo.hpp
+++ b/src/helics/core/EndpointInfo.hpp
@@ -5,10 +5,7 @@ All rights reserved.
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
-#ifndef _HELICS_ENDPOINTINFO_
-#define _HELICS_ENDPOINTINFO_
 
 #include "Core.hpp"
 #include "helics-time.hpp"
@@ -50,5 +47,3 @@ class EndpointInfo
     Time firstMessageTime () const;
 };
 }  // namespace helics
-
-#endif

--- a/src/helics/core/FederateState.hpp
+++ b/src/helics/core/FederateState.hpp
@@ -1,15 +1,11 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
-#ifndef FEDERATE_STATE_H_
-#define FEDERATE_STATE_H_
 #pragma once
 
 #include "../common/BlockingQueue.hpp"
@@ -261,5 +257,4 @@ private:
     */
     bool checkAndSetValue(Core::handle_id_t pub_id, const char *data, uint64_t len);
 };
-}
-#endif
+} // namespace helics

--- a/src/helics/core/FilterFunctions.hpp
+++ b/src/helics/core/FilterFunctions.hpp
@@ -1,15 +1,11 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
-#ifndef FILTER_FUNCTIONS_H_
-#define FILTER_FUNCTIONS_H_
 #pragma once
 
 #include "Core.hpp"
@@ -19,6 +15,7 @@ namespace helics
 {
 class FilterInfo;
 /** data class to manage the ordering of filter operations for an endpoint
+@details thread safety for this class must be managed externally
  */
 class FilterCoordinator
 {
@@ -31,6 +28,4 @@ class FilterCoordinator
     bool hasDestFilter = false;  //!< indicator that an endpoint has a destination filter
     int ongoingTransactions = 0;  //!< counter for the number of filtered message returns expected
 };
-}
-
-#endif
+} // namespace helics

--- a/src/helics/core/ForwardingTimeCoordinator.hpp
+++ b/src/helics/core/ForwardingTimeCoordinator.hpp
@@ -6,6 +6,7 @@ This software was co-developed by Pacific Northwest National Laboratory, operate
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
 */
+
 #pragma once
 
 #include "ActionMessage.hpp"
@@ -28,6 +29,7 @@ private:
     Time time_minDe = timeZero;  //!< the minimum event time of the dependencies
     DependencyInfo::time_state_t time_state = DependencyInfo::time_state_t::time_requested; //!< the current forwarding time state
     Core::federate_id_t lastMinFed = invalid_fed_id; //!< the latest minimum fed
+    Core::federate_id_t parent = invalid_fed_id;  //!< the id for the parent object which should also be a ForwardingTimeCoordinator
     TimeDependencies dependencies;  //!< federates which this Federate is temporally dependent on
     std::vector<Core::federate_id_t> dependents;  //!< federates which temporally depend on this federate
 

--- a/src/helics/core/HandleManager.hpp
+++ b/src/helics/core/HandleManager.hpp
@@ -5,7 +5,6 @@ All rights reserved.
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 #pragma once
 #include "Core.hpp"
@@ -31,15 +30,16 @@ private:
     std::unordered_multimap<std::string, Core::handle_id_t> subscriptions; //!< multimap of subscriptions
     std::unordered_multimap<std::string, Core::handle_id_t> filters;  //!< multimap for all the filters
 public:
+    /** default constructor*/
     HandleManager() = default;
-
+    /** add a handle to manage*/
     BasicHandleInfo *addHandle(Core::handle_id_t id,
         Core::federate_id_t fed_id,
         BasicHandleType what,
         const std::string &key,
         const std::string &type,
         const std::string &units);
-
+    /** add a handle to manage*/
     BasicHandleInfo *addHandle(Core::handle_id_t id,
         Core::federate_id_t fed_id,
         BasicHandleType what,
@@ -49,4 +49,4 @@ public:
         const std::string &type_out);
 };
 
-}
+} // namespace helics

--- a/src/helics/core/NetworkBrokerData.hpp
+++ b/src/helics/core/NetworkBrokerData.hpp
@@ -1,15 +1,12 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
-#ifndef NETWORK_BROKER_DATA_H_
-#define NETWORK_BROKER_DATA_H_
+
 #pragma once
 
 #include <string>
@@ -17,45 +14,44 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 namespace helics
 {
 /** helper class designed to contain the common elements between networking brokers and cores
-    */
+ */
 class NetworkBrokerData
 {
-    public:
-		/** define keys for particular interfaces*/
-        enum class interface_type
-        {	
-            tcp,  //!< using tcp ports for communication
-            udp,	//!< using udp ports for communication
-            both,	//!< using both types of ports for communication
-        };
-        std::string brokerName;  //!< the identifier for the broker
-        std::string brokerAddress;	//!< the address or domain name of the broker
-        std::string localInterface; //!< the interface to use for the local receive ports
-        int portNumber = -1;	//!< the port number for the local interface
-        int brokerPort = -1;  //!< the port number to use for the main broker interface
-        int portStart = -1;  //!< the starting port for automatic port definitions
-    public:
+  public:
+    /** define keys for particular interfaces*/
+    enum class interface_type
+    {
+        tcp,  //!< using tcp ports for communication
+        udp,  //!< using udp ports for communication
+        both,  //!< using both types of ports for communication
+    };
+    std::string brokerName;  //!< the identifier for the broker
+    std::string brokerAddress;  //!< the address or domain name of the broker
+    std::string localInterface;  //!< the interface to use for the local receive ports
+    int portNumber = -1;  //!< the port number for the local interface
+    int brokerPort = -1;  //!< the port number to use for the main broker interface
+    int portStart = -1;  //!< the starting port for automatic port definitions
+  public:
     NetworkBrokerData () = default;
-        /** constructor from the allowed type*/
-        explicit NetworkBrokerData(interface_type type) :allowedType(type) {};
-		/** initalize the properties from input arguments
-		@param argc the number of arguments
-		@param argv the strings as they may have come from the command line
-		@param localAddress a predefined string containing the desired local only address
-		*/
-        void initializeFromArgs(int argc, const char *const *argv, const std::string &localAddress);
-        /** display the help line for the network information
-		*/
-		static void displayHelp();
-        /** set the desired interface type
-		*/
-		void setInterfaceType(interface_type type) {
-            allowedType = type;
-        }
-    private:
-        /** do some checking on the brokerAddress*/
+    /** constructor from the allowed type*/
+    explicit NetworkBrokerData (interface_type type) : allowedType (type){};
+    /** initialize the properties from input arguments
+    @param argc the number of arguments
+    @param argv the strings as they may have come from the command line
+    @param localAddress a predefined string containing the desired local only address
+    */
+    void initializeFromArgs (int argc, const char *const *argv, const std::string &localAddress);
+    /** display the help line for the network information
+     */
+    static void displayHelp ();
+    /** set the desired interface type
+     */
+    void setInterfaceType (interface_type type) { allowedType = type; }
+
+  private:
+    /** do some checking on the brokerAddress*/
     void checkAndUpdateBrokerAddress (const std::string &localAddress);
-        interface_type allowedType = interface_type::both;
+    interface_type allowedType = interface_type::both;
 };
 
 /** generate a string with a full address based on an interface string and port number
@@ -86,10 +82,9 @@ or the interface doesn't use port numbers
 std::pair<std::string, std::string> extractInterfaceandPortString (const std::string &address);
 
 /** get the external ipv4 address of the current computer
-    */
+ */
 std::string getLocalExternalAddressV4 ();
 
 /** get the external ipv4 Ethernet address of the current computer that best matches the listed server*/
 std::string getLocalExternalAddressV4 (const std::string &server);
-}
-#endif /*NETWORK_BROKER_DATA_H_*/
+}  // namespace helics

--- a/src/helics/core/PublicationInfo.hpp
+++ b/src/helics/core/PublicationInfo.hpp
@@ -1,16 +1,13 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
-#ifndef _HELICS_SUBSCRIPTION_
-#define _HELICS_SUBSCRIPTION_
 
+#pragma once
 
 #include "Core.hpp"
 #include "helics-time.hpp"
@@ -54,5 +51,3 @@ class PublicationInfo
     bool CheckSetValue (const char *checkData, uint64_t len);
 };
 } // namespace helics
-
-#endif

--- a/src/helics/core/SubscriptionInfo.hpp
+++ b/src/helics/core/SubscriptionInfo.hpp
@@ -1,15 +1,12 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
-#ifndef _HELICS_SUBSCRIPTIONINFO_
-#define _HELICS_SUBSCRIPTIONINFO_
+#pragma once
 
 #include "helics-time.hpp"
 #include "helics/helics-config.h"
@@ -58,9 +55,7 @@ class SubscriptionInfo
 	@return true if the value has changed
 	*/
     bool updateTime (Time newTime);
-
+    /** get the event based on the event queue*/
     Time nextValueTime () const;
 };
 }  // namespace helics
-
-#endif /* _HELICS_TEST_CORE_ */

--- a/src/helics/core/TestBroker.cpp
+++ b/src/helics/core/TestBroker.cpp
@@ -1,12 +1,10 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 #include "TestBroker.h"
 #include "BrokerFactory.hpp"
@@ -17,6 +15,8 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 #include <fstream>
 
 namespace helics
+{
+namespace testcore
 {
 TestBroker::TestBroker (bool rootBroker) noexcept : CoreBroker (rootBroker) {}
 
@@ -219,4 +219,5 @@ void TestBroker::addRoute (int route_id, const std::string &routeInfo)
 
 std::string TestBroker::getAddress () const { return getIdentifier (); }
 
+} // namespace testcore
 }  // namespace helics

--- a/src/helics/core/TestBroker.h
+++ b/src/helics/core/TestBroker.h
@@ -1,51 +1,56 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
-This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
+This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
+Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
+Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
 */
-#ifndef TEST_BROKER_H_
-#define TEST_BROKER_H_
-#pragma once
 
+#pragma once
 #include "CoreBroker.hpp"
 
 namespace helics
 {
 class CommonCore;
+namespace testcore
+{
 /** class implementing a basic broker that links to other brokers in process memory*/
 class TestBroker : public CoreBroker
 {
-public:
-	/** default constructor*/
-	TestBroker( bool isRoot_=false) noexcept;
-	TestBroker(const std::string &broker_name);
-	/** construct with a pointer to a broker*/
-	TestBroker(std::shared_ptr<TestBroker> nbroker);
-	virtual ~TestBroker();
-	virtual void initializeFromArgs(int argc, const char * const *argv) override;
-protected:
-	virtual void transmit(int32_t route, const ActionMessage &command) override;
+  public:
+    /** default constructor*/
+    TestBroker (bool isRoot_ = false) noexcept;
+    TestBroker (const std::string &broker_name);
+    /** construct with a pointer to a broker*/
+    TestBroker (std::shared_ptr<TestBroker> nbroker);
+    virtual ~TestBroker ();
+    virtual void initializeFromArgs (int argc, const char *const *argv) override;
 
-	virtual void addRoute(int route_id, const std::string &routeInfo) override;
-public:
-	virtual std::string getAddress() const override;
+  protected:
+    virtual void transmit (int32_t route, const ActionMessage &command) override;
+
+    virtual void addRoute (int route_id, const std::string &routeInfo) override;
+
+  public:
+    virtual std::string getAddress () const override;
     /** static method to display the help message*/
-    static void displayHelp(bool localOnly = false);
-protected:
-	virtual bool brokerConnect() override;
-	virtual void brokerDisconnect() override;
-    virtual bool tryReconnect() override;
-private:
-	std::string brokerName;  //!< the name of the higher level broker to connect to
-	std::string brokerInitString;  //!< the initialization string for the higher level broker
-	std::shared_ptr<CoreBroker> tbroker;  //the parent broker;
-										  //void computeDependencies();
-	std::map<int32_t, std::shared_ptr<CoreBroker>> brokerRoutes; //!< map of the routes to other brokers
-	std::map < int32_t, std::shared_ptr<CommonCore>>  coreRoutes; //!< map of the routes to other cores
-	mutable std::mutex routeMutex; //!< mutex lock protecting the route maps
+    static void displayHelp (bool localOnly = false);
+
+  protected:
+    virtual bool brokerConnect () override;
+    virtual void brokerDisconnect () override;
+    virtual bool tryReconnect () override;
+
+  private:
+    std::string brokerName;  //!< the name of the higher level broker to connect to
+    std::string brokerInitString;  //!< the initialization string for the higher level broker
+    std::shared_ptr<CoreBroker> tbroker;  // the parent broker;
+                                          // void computeDependencies();
+    std::map<int32_t, std::shared_ptr<CoreBroker>> brokerRoutes;  //!< map of the routes to other brokers
+    std::map<int32_t, std::shared_ptr<CommonCore>> coreRoutes;  //!< map of the routes to other cores
+    mutable std::mutex routeMutex;  //!< mutex lock protecting the route maps
 };
-}
-#endif
+} // namespace testcore
+} //namespace helics
+

--- a/src/helics/core/TestCore.cpp
+++ b/src/helics/core/TestCore.cpp
@@ -22,6 +22,8 @@ namespace helics
 using federate_id_t = Core::federate_id_t;
 using handle_id_t = Core::handle_id_t;
 
+namespace testcore
+{
 TestCore::TestCore (const std::string &core_name) : CommonCore (core_name) {}
 
 TestCore::TestCore (std::shared_ptr<CoreBroker> nbroker) : tbroker (std::move (nbroker)) {}
@@ -188,4 +190,5 @@ void TestCore::addRoute (int route_id, const std::string &routeInfo)
 
 std::string TestCore::getAddress () const { return getIdentifier (); }
 
+} // namespace testcore
 }  // namespace helics

--- a/src/helics/core/TestCore.h
+++ b/src/helics/core/TestCore.h
@@ -1,15 +1,11 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
-#ifndef _HELICS_TEST_CORE_
-#define _HELICS_TEST_CORE_
 
 #include "CommonCore.hpp"
 //#include "test-broker.h"
@@ -18,44 +14,45 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 namespace helics
 {
 class CoreBroker;
+namespace testcore
+{
 /** an object implementing a local core object that can communicate in process
  */
-class TestCore final: public CommonCore
+class TestCore final : public CommonCore
 {
-  public:
-    /** default constructor*/
-    TestCore () = default;
-	/**construct from a core name*/
-	TestCore(const std::string &core_name);
-    /** construct with a pointer to a broker*/
-    TestCore (std::shared_ptr<CoreBroker> nbroker);
-    /** destructor*/
-    virtual ~TestCore ();  // the destructor is defined so the definition of TestBroker does not need to be
-                           // available in the header
-    virtual void initializeFromArgs (int argc, const char * const *argv) override;
-
-  protected:
-    virtual void transmit (int route_id, const ActionMessage &cmd) override;
-    virtual void addRoute (int route_id, const std::string &routeInfo) override;
 public:
-	virtual std::string getAddress() const override;
+    /** default constructor*/
+    TestCore() = default;
+    /**construct from a core name*/
+    TestCore(const std::string &core_name);
+    /** construct with a pointer to a broker*/
+    TestCore(std::shared_ptr<CoreBroker> nbroker);
+    /** destructor*/
+    virtual ~TestCore();  // the destructor is defined so the definition of TestBroker does not need to be
+                           // available in the header
+    virtual void initializeFromArgs(int argc, const char * const *argv) override;
+
+protected:
+    virtual void transmit(int route_id, const ActionMessage &cmd) override;
+    virtual void addRoute(int route_id, const std::string &routeInfo) override;
+public:
+    virtual std::string getAddress() const override;
 private:
-	//these should only be called by the CommonCore code
-	virtual bool brokerConnect() override;
-	virtual void brokerDisconnect() override;
+    //these should only be called by the CommonCore code
+    virtual bool brokerConnect() override;
+    virtual void brokerDisconnect() override;
     virtual bool tryReconnect() override;
 private:
-	  std::atomic<bool> initialized_{ false };  //!< atomic protecting local initialization
+    std::atomic<bool> initialized_{ false };  //!< atomic protecting local initialization
     std::shared_ptr<CoreBroker> tbroker;  //!<the parent broker;
-	std::string brokerInitString;  //!< the initialization string to use for the Broker
-	std::string brokerName;  //!< the name of the broker to connect to
+    std::string brokerInitString;  //!< the initialization string to use for the Broker
+    std::string brokerName;  //!< the name of the broker to connect to
     // void computeDependencies();
     std::map<int32_t, std::shared_ptr<CoreBroker>> brokerRoutes;  //!< map of the different brokers
     std::map<int32_t, std::shared_ptr<CommonCore>> coreRoutes;  //!< map of the different cores that can be routed to
     mutable std::mutex routeMutex;  //!< mutex that protects the routing info
 };
 
-
+} // namespace testcore
 }  // namespace helics
 
-#endif /* _HELICS_TEST_CORE_ */

--- a/src/helics/core/TimeDependencies.hpp
+++ b/src/helics/core/TimeDependencies.hpp
@@ -6,7 +6,6 @@ This software was co-developed by Pacific Northwest National Laboratory, operate
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
 */
-
 #pragma once
 
 #include "Core.hpp"
@@ -31,21 +30,21 @@ class DependencyInfo
         time_requested = 5,
     };
     Core::federate_id_t fedID = invalid_fed_id;  //!< identifier for the dependency
-    Core::federate_id_t minFed = invalid_fed_id; //!< identfier for the min dependency
+    Core::federate_id_t minFed = invalid_fed_id;  //!< identfier for the min dependency
     time_state_t time_state = time_state_t::initialized;  //!< the current state of the dependency
-    
+
     Time Tnext = negEpsilon;  //!< next possible message or value
     Time Te = timeZero;  //!< the next currently scheduled event
     Time Tdemin = timeZero;  //!< min dependency event time
-    Time forwardEvent = Time::maxVal(); //!< a predicted event
+    Time forwardEvent = Time::maxVal ();  //!< a predicted event
     /** default constructor*/
     DependencyInfo () = default;
     /** construct from a federate id*/
     explicit DependencyInfo (Core::federate_id_t id) : fedID (id){};
 
-	/** process a dependency related message
-	@param m  a reference to an action message that contains some instructions for modifying dependencies
-	@return true if something was modified by the message*/
+    /** process a dependency related message
+    @param m  a reference to an action message that contains some instructions for modifying dependencies
+    @return true if something was modified by the message*/
     bool ProcessMessage (const ActionMessage &m);
 };
 
@@ -80,18 +79,18 @@ class TimeDependencies
     /**  const iterator to first dependency*/
     auto cend () const { return dependencies.cend (); }
 
-	/** get a pointer to the dependency information for a particular object*/
+    /** get a pointer to the dependency information for a particular object*/
     DependencyInfo *getDependencyInfo (Core::federate_id_t id);
 
-	/** check if the dependencies would allow entry to exec mode*/
+    /** check if the dependencies would allow entry to exec mode*/
     bool checkIfReadyForExecEntry (bool iterating) const;
-	/** check if the dependencies would allow a grant of the time
-	@param iterating true if the object is iterating
-	@param desiredGrantTime  the time to check for granting
-	@return true if the object is ready
-	*/
+    /** check if the dependencies would allow a grant of the time
+    @param iterating true if the object is iterating
+    @param desiredGrantTime  the time to check for granting
+    @return true if the object is ready
+    */
     bool checkIfReadyForTimeGrant (bool iterating, Time desiredGrantTime) const;
     void resetIteratingExecRequests ();
     void resetIteratingTimeRequests (Time requestTime);
 };
-}
+}  // namespace helics

--- a/src/helics/core/core-types.hpp
+++ b/src/helics/core/core-types.hpp
@@ -1,15 +1,12 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
-#ifndef _CORE_TYPES_H_
-#define _CORE_TYPES_H_
+
 #pragma once
 
 #include <string>
@@ -107,5 +104,3 @@ bool isCoreTypeAvailable (core_type type) noexcept;
 
 #define PUBLICATION_REQUIRED helics::handle_check_mode::required
 #define PUBLICATION_OPTIONAL helics::handle_check_mode::optional
-
-#endif

--- a/src/helics/core/helics-broker.cpp
+++ b/src/helics/core/helics-broker.cpp
@@ -29,7 +29,7 @@ int main (int argc, char *argv[])
         }
         else if (exit_early == helics::versionReturn)
         {
-            std::cout << helics::versionString() << '\n';
+            std::cout << helics::versionString << '\n';
         }
         return 0;
     }

--- a/src/helics/core/helics-time.cpp
+++ b/src/helics/core/helics-time.cpp
@@ -1,12 +1,10 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 
 #include "helics-time.hpp"

--- a/src/helics/core/helics-time.hpp
+++ b/src/helics/core/helics-time.hpp
@@ -64,4 +64,4 @@ Time loadTimeFromString(const std::string &timeString, timeUnits defUnit);
 */
 timeUnits timeUnitsFromString(const std::string &unitString);
 
-}
+} // namespace helics

--- a/src/helics/core/helicsVersion.cpp
+++ b/src/helics/core/helicsVersion.cpp
@@ -1,25 +1,15 @@
+/*
+Copyright (C) 2017-2018, Battelle Memorial Institute
+All rights reserved.
+
+This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
+Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
+Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
+*/
+
 #include "helicsVersion.hpp"
 
 namespace helics
 {
-std::string versionString ()
-{
-    std::string vstr = std::to_string (HELICS_VERSION_MAJOR);
-    vstr.push_back ('.');
-    vstr.append (std::to_string (HELICS_VERSION_MINOR));
-    vstr.push_back ('.');
-    vstr.append (std::to_string (HELICS_VERSION_PATCH));
-
-    std::string buildStr (HELICS_VERSION_BUILD);
-    if (!buildStr.empty ())
-    {
-        vstr.push_back ('-');
-        vstr.append (buildStr);
-    }
-    vstr.push_back (' ');
-    vstr.push_back ('(');
-    vstr += HELICS_DATE;
-    vstr.push_back (')');
-    return vstr;
-}
+const char * versionString = HELICS_VERSION_STRING;
 }

--- a/src/helics/core/helicsVersion.hpp
+++ b/src/helics/core/helicsVersion.hpp
@@ -19,7 +19,7 @@ namespace helics
 {
 
 /** @returns a string containing version information*/
-std::string versionString ();
+extern const char * versionString;
 
 /** get the Major version number*/
 constexpr int versionMajor=HELICS_VERSION_MAJOR;

--- a/src/helics/core/ipc/IpcBroker.cpp
+++ b/src/helics/core/ipc/IpcBroker.cpp
@@ -36,86 +36,89 @@ constexpr size_t maxMessageCount = 256;
 #define CLOSE_IPC 23425
 namespace helics
 {
+namespace ipc
+{
 using namespace std::string_literals;
 static const ArgDescriptors extraArgs{ {"queueloc"s , "the named location of the shared queue"s},
                                       {"broker,b"s, "identifier for the broker"s},
                                       {"broker_address", "location of the broker i.e network address"},
-                                      {"brokerinit"s, "the initialization string for the broker"s}};
+                                      {"brokerinit"s, "the initialization string for the broker"s} };
 
-IpcBroker::IpcBroker (bool rootBroker) noexcept : CommsBroker (rootBroker) {}
+IpcBroker::IpcBroker(bool rootBroker) noexcept : CommsBroker(rootBroker) {}
 
-IpcBroker::IpcBroker (const std::string &broker_name) : CommsBroker (broker_name) {}
+IpcBroker::IpcBroker(const std::string &broker_name) : CommsBroker(broker_name) {}
 
-IpcBroker::~IpcBroker () = default;
+IpcBroker::~IpcBroker() = default;
 
-void IpcBroker::displayHelp (bool local_only)
+void IpcBroker::displayHelp(bool local_only)
 {
     std::cout << " Help for Interprocess Broker: \n";
     variable_map vm;
-    const char *const argV[] = {"", "--help"};
-    argumentParser (2, argV, vm, extraArgs);
+    const char *const argV[] = { "", "--help" };
+    argumentParser(2, argV, vm, extraArgs);
     if (!local_only)
     {
-        CoreBroker::displayHelp ();
+        CoreBroker::displayHelp();
     }
 }
 
-void IpcBroker::initializeFromArgs (int argc, const char *const *argv)
+void IpcBroker::initializeFromArgs(int argc, const char *const *argv)
 {
     if (brokerState == broker_state_t::created)
     {
         variable_map vm;
-        argumentParser (argc, argv, vm, extraArgs);
+        argumentParser(argc, argv, vm, extraArgs);
 
-        if (vm.count ("broker") > 0)
+        if (vm.count("broker") > 0)
         {
-            brokername = vm["broker"].as<std::string> ();
+            brokername = vm["broker"].as<std::string>();
         }
 
-        if (vm.count ("broker_address") > 0)
+        if (vm.count("broker_address") > 0)
         {
-            brokerloc = vm["broker_address"].as<std::string> ();
+            brokerloc = vm["broker_address"].as<std::string>();
         }
 
-        if (vm.count ("fileloc") > 0)
+        if (vm.count("fileloc") > 0)
         {
-            fileloc = vm["fileloc"].as<std::string> ();
+            fileloc = vm["fileloc"].as<std::string>();
         }
         noAutomaticID = true;
-        CoreBroker::initializeFromArgs (argc, argv);
-        if (getIdentifier ().empty ())
+        CoreBroker::initializeFromArgs(argc, argv);
+        if (getIdentifier().empty())
         {
-            setIdentifier ("_ipc_broker");
+            setIdentifier("_ipc_broker");
         }
     }
 }
 
-bool IpcBroker::brokerConnect ()
+bool IpcBroker::brokerConnect()
 {
-    std::lock_guard<std::mutex> lock (dataMutex);  // mutex protecting the other information in the ipcBroker
-    if (fileloc.empty ())
+    std::lock_guard<std::mutex> lock(dataMutex);  // mutex protecting the other information in the ipcBroker
+    if (fileloc.empty())
     {
-        fileloc = getIdentifier () + "_queue.hqf";
+        fileloc = getIdentifier() + "_queue.hqf";
     }
 
-    if ((brokerloc.empty ()) && (brokername.empty ()))
+    if ((brokerloc.empty()) && (brokername.empty()))
     {
-        setAsRoot ();
+        setAsRoot();
     }
-    else if (brokerloc.empty ())
+    else if (brokerloc.empty())
     {
         brokerloc = brokername + "_queue.hqf";
     }
-    comms = std::make_unique<IpcComms> (fileloc, brokerloc);
-    comms->setCallback ([this](ActionMessage M) { addActionMessage (std::move (M)); });
-    comms->setMessageSize (maxMessageSize, maxMessageCount);
-    return comms->connect ();
+    comms = std::make_unique<IpcComms>(fileloc, brokerloc);
+    comms->setCallback([this](ActionMessage M) { addActionMessage(std::move(M)); });
+    comms->setMessageSize(maxMessageSize, maxMessageCount);
+    return comms->connect();
 }
 
-std::string IpcBroker::getAddress () const
+std::string IpcBroker::getAddress() const
 {
-    std::lock_guard<std::mutex> lock (dataMutex);
+    std::lock_guard<std::mutex> lock(dataMutex);
     return fileloc;
 }
 
+} // namespace ipc
 }  // namespace helics

--- a/src/helics/core/ipc/IpcBroker.h
+++ b/src/helics/core/ipc/IpcBroker.h
@@ -1,43 +1,44 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
-This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
+This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
+Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
+Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
 */
-#ifndef IPC_BROKER_H_
-#define IPC_BROKER_H_
 #pragma once
 
-#include "../CoreBroker.hpp"
 #include "../CommsBroker.hpp"
+#include "../CoreBroker.hpp"
 
 namespace helics
 {
-
+namespace ipc
+{
 class IpcComms;
 
-class IpcBroker final:public CommsBroker<IpcComms,CoreBroker>
+class IpcBroker final : public CommsBroker<IpcComms, CoreBroker>
 {
 public:
-	/** default constructor*/
-	IpcBroker(bool rootBroker = false) noexcept;
-	IpcBroker(const std::string &broker_name);
+    /** default constructor*/
+    IpcBroker(bool rootBroker = false) noexcept;
+    IpcBroker(const std::string &broker_name);
 
-	static void displayHelp(bool local_only = false);
-	void initializeFromArgs(int argc, const char * const *argv) override;
+    static void displayHelp(bool local_only = false);
+    void initializeFromArgs(int argc, const char *const *argv) override;
 
-	/**destructor*/
-	virtual ~IpcBroker();
+    /**destructor*/
+    virtual ~IpcBroker();
 
-	virtual std::string getAddress() const override;
+    virtual std::string getAddress() const override;
+
 private:
-	virtual bool brokerConnect() override;
+    virtual bool brokerConnect() override;
+
 private:
-	std::string fileloc; //!< the name of the file that the shared memory queue is located
-	std::string brokerloc; //!< the name of the shared queue of the broker
-	std::string brokername; //!< the name of the broker
+    std::string fileloc;  //!< the name of the file that the shared memory queue is located
+    std::string brokerloc;  //!< the name of the shared queue of the broker
+    std::string brokername;  //!< the name of the broker
 };
-} //namespace helics
-#endif
+} // namespace ipc
+}  // namespace helics

--- a/src/helics/core/ipc/IpcComms.cpp
+++ b/src/helics/core/ipc/IpcComms.cpp
@@ -26,6 +26,8 @@ using ipc_state = boost::interprocess::shared_memory_object;
 
 namespace helics
 {
+namespace ipc
+{
 IpcComms::IpcComms (const std::string &brokerTarget, const std::string &localTarget)
     : CommsInterface (brokerTarget, localTarget)
 {
@@ -288,4 +290,5 @@ void IpcComms::closeReceiver ()
     }
 }
 
+} // namespace ipc
 }  // namespace helics

--- a/src/helics/core/ipc/IpcComms.h
+++ b/src/helics/core/ipc/IpcComms.h
@@ -1,45 +1,42 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
-This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
+This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
+Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
+Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
 */
-#ifndef _HELICS_IPC_COMMS_
-#define _HELICS_IPC_COMMS_
 #pragma once
 
 #include "../CommsInterface.hpp"
 #include <atomic>
 
-namespace helics {
-
+namespace helics
+{
+namespace ipc
+{
 /** implementation for the core that uses boost interprocess messages to communicate*/
-class IpcComms final:public CommsInterface {
+class IpcComms final : public CommsInterface
+{
+  public:
+    /** default constructor*/
+    IpcComms () = default;
+    IpcComms (const std::string &brokerTarget, const std::string &localTarget);
+    /** destructor*/
+    ~IpcComms ();
 
-public:
-	/** default constructor*/
-	IpcComms() = default;
-	IpcComms(const std::string &brokerTarget, const std::string &localTarget);
-	/** destructor*/
-	~IpcComms();
+  private:
+    std::atomic<int> ipcbackchannel{0};  //!< a back channel message system if the primary is not working
 
-private:
-    std::atomic<int> ipcbackchannel{0}; //!< a back channel message system if the primary is not working
+    virtual void queue_rx_function () override;  //!< the functional loop for the receive queue
+    virtual void queue_tx_function () override;  //!< the loop for transmitting data
+    virtual void closeReceiver () override;  //!< function to instruct the receiver loop to close
 
-	virtual void queue_rx_function() override;	//!< the functional loop for the receive queue
-	virtual void queue_tx_function() override;  //!< the loop for transmitting data
-	virtual void closeReceiver() override;  //!< function to instruct the receiver loop to close
-	
-private:
-	
+  private:
 };
 
 #define IPC_BACKCHANNEL_TRY_RESET 2
 #define IPC_BACKCHANNEL_DISCONNECT 4
 
-} // namespace helics
-
-#endif /* _HELICS_IPC_COMMS_ */
-
+}  // namespace ipc
+}  // namespace helics

--- a/src/helics/core/ipc/IpcCore.cpp
+++ b/src/helics/core/ipc/IpcCore.cpp
@@ -1,12 +1,10 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 #include "IpcCore.h"
 #include "../Core.hpp"
@@ -29,6 +27,8 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 #include <boost/filesystem.hpp>
 
 namespace helics
+{
+namespace ipc
 {
 using namespace std::string_literals;
 static const ArgDescriptors extraArgs{
@@ -101,4 +101,5 @@ std::string IpcCore::getAddress () const
     return fileloc;
 }
 
+} // namespace ipc
 }  // namespace helics

--- a/src/helics/core/ipc/IpcCore.h
+++ b/src/helics/core/ipc/IpcCore.h
@@ -1,42 +1,43 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
-This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
+This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
+Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
+Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
 */
-#ifndef _HELICS_IPC_CORE_
-#define _HELICS_IPC_CORE_
+
 #pragma once
 
 #include "../CommonCore.hpp"
 #include "../CommsBroker.hpp"
-namespace helics {
-
+namespace helics
+{
+namespace ipc
+{
 class IpcComms;
 
 /** implementation for the core that uses Interprocess messages to communicate*/
-class IpcCore final: public CommsBroker<IpcComms,CommonCore> {
+class IpcCore final : public CommsBroker<IpcComms, CommonCore>
+{
+  public:
+    /** default constructor*/
+    IpcCore () noexcept;
+    IpcCore (const std::string &core_name);
+    /** destructor*/
+    ~IpcCore ();
+    virtual void initializeFromArgs (int argc, const char *const *argv) override;
 
-public:
-	/** default constructor*/
-  IpcCore() noexcept;
-  IpcCore(const std::string &core_name);
-  /** destructor*/
-  ~IpcCore();
-  virtual void initializeFromArgs (int argc, const char * const *argv) override;
-public:
-	virtual std::string getAddress() const override;
-private:
-	virtual bool brokerConnect() override;
- 
-	std::string fileloc; //!< the location of the file queue
-	std::string brokerloc;	//!< the location of the broker	queue
-	std::string brokername;	//!< the name of the broker
+  public:
+    virtual std::string getAddress () const override;
+
+  private:
+    virtual bool brokerConnect () override;
+
+    std::string fileloc;  //!< the location of the file queue
+    std::string brokerloc;  //!< the location of the broker	queue
+    std::string brokername;  //!< the name of the broker
 };
 
-
-} // namespace helics
- 
-#endif /* _HELICS_ZEROMQ_CORE_ */
+}  // namespace ipc
+}  // namespace helics

--- a/src/helics/core/loggingHelper.hpp
+++ b/src/helics/core/loggingHelper.hpp
@@ -1,15 +1,12 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
-#ifndef _HELICS_LOGGING_HELPER_
-#define _HELICS_LOGGING_HELPER_
+
 #pragma once
 
 #include "helics/helics-config.h"
@@ -18,7 +15,6 @@ this file is meant to be included in the commonCore.cpp and coreBroker.cpp
 and inherited class files
 it assumes some knowledge of the internals of those programs via MACROS
 using elsewhere is probably not going to work.  Someday this will be made more generic
-
 */
 
 /** enumeration of defined print levels*/
@@ -66,5 +62,3 @@ enum log_level : int
 #define LOG_DEBUG(id, ident, message)
 #define LOG_TRACE(id, ident, message)
 #endif
-
-#endif /* _HELICS_LOGGING_HELPER_ */

--- a/src/helics/core/mpi/MpiBroker.h
+++ b/src/helics/core/mpi/MpiBroker.h
@@ -1,42 +1,43 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
-This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
+This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
+Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
+Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
 */
-#ifndef MPI_BROKER_H_
-#define MPI_BROKER_H_
 #pragma once
 
-#include "../CoreBroker.hpp"
 #include "../CommsBroker.hpp"
+#include "../CoreBroker.hpp"
 
 namespace helics
 {
-
+namespace mpi
+{
 class MpiComms;
 
-class MpiBroker final:public CommsBroker<MpiComms,CoreBroker>
+class MpiBroker final : public CommsBroker<MpiComms, CoreBroker>
 {
-public:
-	/** default constructor*/
-	MpiBroker(bool rootBroker = false) noexcept;
-	MpiBroker(const std::string &broker_name);
+  public:
+    /** default constructor*/
+    MpiBroker (bool rootBroker = false) noexcept;
+    MpiBroker (const std::string &broker_name);
 
-	void initializeFromArgs(int argc, const char * const *argv) override;
+    void initializeFromArgs (int argc, const char *const *argv) override;
 
-	/**destructor*/
-	virtual ~MpiBroker();
+    /**destructor*/
+    virtual ~MpiBroker ();
 
-	virtual std::string getAddress() const override;
-	static void displayHelp(bool local_only = false);
-private:
-	virtual bool brokerConnect() override;
-    std::string brokerAddress; //!< the mpi rank:tag of the parent broker
+    virtual std::string getAddress () const override;
+    static void displayHelp (bool local_only = false);
+
+  private:
+    virtual bool brokerConnect () override;
+    std::string brokerAddress;  //!< the mpi rank:tag of the parent broker
     int brokerRank;
     int brokerTag;
 };
-}
-#endif
+} // namespace mpi
+} // namespace helics
+

--- a/src/helics/core/mpi/MpiComms.cpp
+++ b/src/helics/core/mpi/MpiComms.cpp
@@ -1,12 +1,10 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 #include "MpiComms.h"
 #include "MpiService.h"
@@ -16,7 +14,8 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 
 namespace helics
 {
-
+namespace mpi
+{
 MpiComms::MpiComms ()
     : shutdown (false)
 {
@@ -193,5 +192,5 @@ void MpiComms::closeReceiver() {
     cmd.index = CLOSE_RECEIVER;
     rxMessageQueue.push (cmd);
 }
-
+} // namespace mpi
 }  // namespace helics

--- a/src/helics/core/mpi/MpiComms.h
+++ b/src/helics/core/mpi/MpiComms.h
@@ -1,62 +1,65 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
-This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
+This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
+Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
+Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
 */
 #pragma once
 
-#include "../CommsInterface.hpp"
 #include "../../common/BlockingQueue.hpp"
+#include "../CommsInterface.hpp"
+#include "helics/helics-config.h"
 #include <atomic>
+#include <future>
+#include <mutex>
 #include <set>
 #include <string>
-#include <future>
 #include <vector>
-#include <mutex>
-#include "helics/helics-config.h"
 
-namespace helics {
-
+namespace helics
+{
+namespace mpi
+{
 /** implementation for the communication interface that uses MPI to communicate*/
-class MpiComms final:public CommsInterface {
+class MpiComms final : public CommsInterface
+{
+  public:
+    /** default constructor*/
+    MpiComms ();
+    MpiComms (const std::string &brokerAddress);
+    /** destructor*/
+    ~MpiComms ();
 
-public:
-	/** default constructor*/
-	MpiComms();
-    MpiComms(const std::string &brokerAddress);
-	/** destructor*/
-	~MpiComms();
-private:
-    std::string brokerAddress; //!< the mpi rank:tag of the broker
-    std::string commAddress; //!< the mpi rank:tag of this comm object
+  private:
+    std::string brokerAddress;  //!< the mpi rank:tag of the broker
+    std::string commAddress;  //!< the mpi rank:tag of this comm object
 
     std::atomic<bool> shutdown;
-    
-    virtual void queue_rx_function() override;	//!< the functional loop for the receive queue
-    virtual void queue_tx_function() override;  //!< the loop for transmitting data
+
+    virtual void queue_rx_function () override;  //!< the functional loop for the receive queue
+    virtual void queue_tx_function () override;  //!< the loop for transmitting data
 
     /** process an incoming message
     return code for required action 0=NONE, -1 TERMINATE*/
-    int processIncomingMessage(ActionMessage &cmd);
+    int processIncomingMessage (ActionMessage &cmd);
 
     /** queue for pending incoming messages*/
     BlockingQueue<ActionMessage> rxMessageQueue;
     /** queue for pending outgoing messages*/
     BlockingQueue<std::pair<std::string, std::vector<char>>> txMessageQueue;
 
-	std::atomic<bool> hasBroker{ false };
-    virtual void closeReceiver() override;  //!< function to instruct the receiver loop to close
+    std::atomic<bool> hasBroker{false};
+    virtual void closeReceiver () override;  //!< function to instruct the receiver loop to close
 
     void setBrokerAddress (const std::string &address) { brokerAddress = address; }
-public:
-	std::string getAddress () { return commAddress; }
-    BlockingQueue<ActionMessage>& getRxMessageQueue () { return rxMessageQueue; }
-    BlockingQueue<std::pair<std::string, std::vector<char>>>& getTxMessageQueue () { return txMessageQueue; }
+
+  public:
+    std::string getAddress () { return commAddress; }
+    BlockingQueue<ActionMessage> &getRxMessageQueue () { return rxMessageQueue; }
+    BlockingQueue<std::pair<std::string, std::vector<char>>> &getTxMessageQueue () { return txMessageQueue; }
 };
 
-
-} // namespace helics
-
+} // namespace mpi
+}  // namespace helics

--- a/src/helics/core/mpi/MpiCore.cpp
+++ b/src/helics/core/mpi/MpiCore.cpp
@@ -1,12 +1,10 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 #include "MpiCore.h"
 #include "MpiComms.h"
@@ -16,6 +14,8 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 #include <mpi.h>
 
 namespace helics
+{
+namespace mpi
 {
 MpiCore::MpiCore () noexcept {}
 
@@ -79,4 +79,5 @@ std::string MpiCore::getAddress () const
     return comms->getAddress();
 }
 
+} // namespace mpi
 }  // namespace helics

--- a/src/helics/core/mpi/MpiCore.h
+++ b/src/helics/core/mpi/MpiCore.h
@@ -1,41 +1,41 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
-This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
+This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
+Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
+Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
 */
-#ifndef _HELICS_MPI_CORE_
-#define _HELICS_MPI_CORE_
+
 #pragma once
 
 #include "../CommonCore.hpp"
 #include "../CommsBroker.hpp"
-namespace helics {
-
+namespace helics
+{
+namespace mpi
+{
 class MpiComms;
 /** implementation for the core that uses mpi messages to communicate*/
-class MpiCore final: public CommsBroker<MpiComms,CommonCore> {
+class MpiCore final : public CommsBroker<MpiComms, CommonCore>
+{
+  public:
+    /** default constructor*/
+    MpiCore () noexcept;
+    MpiCore (const std::string &core_name);
+    ~MpiCore ();
+    virtual void initializeFromArgs (int argc, const char *const *argv) override;
 
-public:
-	/** default constructor*/
-  MpiCore() noexcept;
-  MpiCore(const std::string &core_name);
-  ~MpiCore();
-  virtual void initializeFromArgs (int argc, const char * const *argv) override;
-         
-public:
-	virtual std::string getAddress() const override;
-private:
-    std::string brokerAddress; //!< the mpi rank:tag of the broker
+  public:
+    virtual std::string getAddress () const override;
+
+  private:
+    std::string brokerAddress;  //!< the mpi rank:tag of the broker
     int brokerRank;
     int brokerTag;
-    virtual bool brokerConnect() override;
- 
+    virtual bool brokerConnect () override;
 };
 
+} // namespace mpi
+}  // namespace helics
 
-} // namespace helics
- 
-#endif /* _HELICS_MPI_CORE_ */

--- a/src/helics/core/mpi/MpiService.cpp
+++ b/src/helics/core/mpi/MpiService.cpp
@@ -10,7 +10,8 @@ This software was co-developed by Pacific Northwest National Laboratory, operate
 #include "MpiService.h"
 
 namespace helics {
-
+namespace mpi
+{
 MPI_Comm MpiService::mpiCommunicator = MPI_COMM_NULL;
 bool MpiService::startServiceThread = true;
 
@@ -340,4 +341,5 @@ void MpiService::drainRemainingMessages ()
     }
 }
 
+} // namespace mpi
 } // namespace helics

--- a/src/helics/core/mpi/MpiService.h
+++ b/src/helics/core/mpi/MpiService.h
@@ -3,59 +3,66 @@
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
-This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
+This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
+Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
+Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
 
 */
 #pragma once
 
-#include "MpiComms.h"
 #include "../../common/BlockingQueue.hpp"
 #include "../ActionMessage.hpp"
+#include "MpiComms.h"
+#include "helics/helics-config.h"
 #include <atomic>
-#include <string>
 #include <functional>
 #include <list>
-#include <vector>
-#include <utility>
-#include <thread>
 #include <memory>
 #include <mutex>
-#include "helics/helics-config.h"
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
 
 #include <mpi.h>
 
-namespace helics {
-
+namespace helics
+{
+namespace mpi
+{
 /** service for using MPI to communicate*/
-class MpiService {
-
-public:
-    static MpiService& getInstance();
+class MpiService
+{
+  public:
+    static MpiService &getInstance ();
     static void setMpiCommunicator (MPI_Comm communicator);
     static void setStartServiceThread (bool start);
 
     std::string addMpiComms (MpiComms *comm);
     void removeMpiComms (MpiComms *comm);
     std::string getAddress (MpiComms *comm);
-    int getRank();
+    int getRank ();
     int getTag (MpiComms *comm);
 
-    void sendMessage (std::string address, std::vector<char> message) { txMessageQueue.emplace (address, std::move (message)); }
+    void sendMessage (std::string address, std::vector<char> message)
+    {
+        txMessageQueue.emplace (address, std::move (message));
+    }
 
     void sendAndReceiveMessages ();
     void drainRemainingMessages ();
 
-private:
-    MpiService();
-    ~MpiService();
-    MpiService(const MpiService&) = delete;
-    MpiService& operator=(const MpiService&) = delete;
+  private:
+    MpiService ();
+    ~MpiService ();
+    MpiService (const MpiService &) = delete;
+    MpiService &operator= (const MpiService &) = delete;
 
     int commRank;
     static MPI_Comm mpiCommunicator;
     static bool startServiceThread;
 
-    std::vector<MpiComms*> comms;
+    std::vector<MpiComms *> comms;
     std::list<std::pair<MPI_Request, std::vector<char>>> send_requests;
     BlockingQueue<std::pair<std::string, std::vector<char>>> txMessageQueue;
 
@@ -65,12 +72,11 @@ private:
     std::atomic<bool> stop_service;
     std::unique_ptr<std::thread> service_thread;
 
-    void startService();
-    void serviceLoop();
+    void startService ();
+    void serviceLoop ();
 
-    bool initMPI();
+    bool initMPI ();
 };
 
-
-} // namespace helics
-
+} // namespace mpi
+}  // namespace helics

--- a/src/helics/core/tcp/TcpBroker.cpp
+++ b/src/helics/core/tcp/TcpBroker.cpp
@@ -1,17 +1,17 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 #include "TcpBroker.h"
 #include "TcpComms.h"
 
 namespace helics
+{
+namespace tcp
 {
 TcpBroker::TcpBroker (bool rootBroker) noexcept : CommsBroker (rootBroker) {}
 
@@ -71,4 +71,6 @@ std::string TcpBroker::getAddress () const
     }
     return makePortAddress (netInfo.localInterface, netInfo.portNumber);
 }
+
+}  // namespace tcp
 }  // namespace helics

--- a/src/helics/core/tcp/TcpBroker.h
+++ b/src/helics/core/tcp/TcpBroker.h
@@ -1,43 +1,44 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
-This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
+This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
+Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
+Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
 */
-#ifndef TCP_BROKER_H_
-#define TCP_BROKER_H_
+
 #pragma once
 
-#include "../CoreBroker.hpp"
 #include "../CommsBroker.hpp"
+#include "../CoreBroker.hpp"
 #include "../NetworkBrokerData.hpp"
 
 namespace helics
 {
-
+namespace tcp
+{
 class TcpComms;
 
-class TcpBroker final:public CommsBroker<TcpComms,CoreBroker>
+class TcpBroker final : public CommsBroker<TcpComms, CoreBroker>
 {
-public:
-	/** default constructor*/
-	TcpBroker(bool rootBroker = false) noexcept;
-	TcpBroker(const std::string &broker_name);
+  public:
+    /** default constructor*/
+    TcpBroker (bool rootBroker = false) noexcept;
+    TcpBroker (const std::string &broker_name);
 
-	void initializeFromArgs(int argc, const char * const *argv) override;
+    void initializeFromArgs (int argc, const char *const *argv) override;
 
-	/**destructor*/
-	virtual ~TcpBroker();
+    /**destructor*/
+    virtual ~TcpBroker ();
 
-	virtual std::string getAddress() const override;
-	static void displayHelp(bool local_only = false);
-private:
-	virtual bool brokerConnect() override;
-	
-    NetworkBrokerData netInfo{ NetworkBrokerData::interface_type::tcp };  //!< structure containing the networking information
+    virtual std::string getAddress () const override;
+    static void displayHelp (bool local_only = false);
 
+  private:
+    virtual bool brokerConnect () override;
+
+    NetworkBrokerData netInfo{
+      NetworkBrokerData::interface_type::tcp};  //!< structure containing the networking information
 };
-}
-#endif
+}  // namespace tcp
+}  // namespace helics

--- a/src/helics/core/tcp/TcpComms.cpp
+++ b/src/helics/core/tcp/TcpComms.cpp
@@ -22,6 +22,7 @@ static const int DEFAULT_TCP_BROKER_PORT_NUMBER = 24160;
 
 namespace helics
 {
+namespace tcp {
 using boost::asio::ip::tcp;
 TcpComms::TcpComms () noexcept {}
 
@@ -605,4 +606,6 @@ void TcpComms::closeReceiver ()
 }
 
 std::string TcpComms::getAddress () const { return makePortAddress (localTarget_, PortNumber); }
+
+} // namespace tcp
 }  // namespace helics

--- a/src/helics/core/tcp/TcpComms.h
+++ b/src/helics/core/tcp/TcpComms.h
@@ -1,110 +1,113 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
-This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
+This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
+Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
+Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
 */
-#ifndef _HELICS_TCP_COMMS_
-#define _HELICS_TCP_COMMS_
+
 #pragma once
 
-#include "../CommsInterface.hpp"
 #include "../../common/BlockingQueue.hpp"
+#include "../CommsInterface.hpp"
 #include <atomic>
 #include <set>
 #include <string>
 
-
-#if (BOOST_VERSION_LEVEL >=2)
+#if (BOOST_VERSION_LEVEL >= 2)
 namespace boost
 {
-    namespace asio
-    {
-        class io_context;
-        using io_service = io_context;
-    }
+namespace asio
+{
+class io_context;
+using io_service = io_context;
+}
 }
 #else
 namespace boost
 {
-    namespace asio
-    {
-        class io_service;
-    }
+namespace asio
+{
+class io_service;
+}
 }
 #endif
 
 namespace boost
 {
-    namespace system
-    {
-        class error_code;
-    }
+namespace system
+{
+class error_code;
 }
+}
+
+
+
+namespace helics
+{
+namespace tcp
+{
 
 class TcpRxConnection;
 class TcpConnection;
 
-namespace helics {
-
-
 /** implementation for the communication interface that uses TCP messages to communicate*/
-class TcpComms final:public CommsInterface {
+class TcpComms final : public CommsInterface
+{
+  public:
+    /** default constructor*/
+    TcpComms () noexcept;
+    TcpComms (const std::string &brokerTarget, const std::string &localTarget);
+    TcpComms (const NetworkBrokerData &netInfo);
+    /** destructor*/
+    ~TcpComms ();
+    /** set the port numbers for the local ports*/
+    void setBrokerPort (int brokerPortNumber);
+    void setPortNumber (int localPortNumber);
+    void setAutomaticPortStartPort (int startingPort);
 
-public:
-	/** default constructor*/
-	TcpComms() noexcept;
-	TcpComms(const std::string &brokerTarget, const std::string &localTarget);
-    TcpComms(const NetworkBrokerData &netInfo);
-	/** destructor*/
-	~TcpComms();
-	/** set the port numbers for the local ports*/
-	void setBrokerPort(int brokerPortNumber);
-	void setPortNumber(int localPortNumber);
-	void setAutomaticPortStartPort(int startingPort);
-private:
-	int brokerPort = -1;
-	std::atomic<int> PortNumber{ -1 };
-	std::set<int> usedPortNumbers;
-	int openPortStart = -1;
-	std::atomic<bool> hasBroker{ false };
-	virtual void queue_rx_function() override;	//!< the functional loop for the receive queue
-	virtual void queue_tx_function() override;  //!< the loop for transmitting data
-	
-	virtual void closeReceiver() override;  //!< function to instruct the receiver loop to close
-	/** find an open port for a subBroker*/
-	int findOpenPort();  
-	/** process an incoming message
-	return code for required action 0=NONE, -1 TERMINATE*/
-	int processIncomingMessage(ActionMessage &cmd);
-    ActionMessage generateReplyToIncomingMessage(ActionMessage &cmd);
-    //promise and future for communicating port number from tx_thread to rx_thread
+  private:
+    int brokerPort = -1;
+    std::atomic<int> PortNumber{-1};
+    std::set<int> usedPortNumbers;
+    int openPortStart = -1;
+    std::atomic<bool> hasBroker{false};
+    virtual void queue_rx_function () override;  //!< the functional loop for the receive queue
+    virtual void queue_tx_function () override;  //!< the loop for transmitting data
+
+    virtual void closeReceiver () override;  //!< function to instruct the receiver loop to close
+    /** find an open port for a subBroker*/
+    int findOpenPort ();
+    /** process an incoming message
+    return code for required action 0=NONE, -1 TERMINATE*/
+    int processIncomingMessage (ActionMessage &cmd);
+    ActionMessage generateReplyToIncomingMessage (ActionMessage &cmd);
+    // promise and future for communicating port number from tx_thread to rx_thread
     BlockingQueue<ActionMessage> rxMessageQueue;
 
-    void txReceive(const char *data, size_t bytes_received, const std::string &errorMessage);
+    void txReceive (const char *data, size_t bytes_received, const std::string &errorMessage);
 
-    void txPriorityReceive(std::shared_ptr<TcpConnection> connection, const char *data, size_t bytes_received, const boost::system::error_code &error);
-   /** callback function for receiving data asynchronously from the socket
-   @param connection pointer to the connection
-   @param data the pointer to the data
-   @param bytes_received the length of the received data
-   @return a the number of bytes used by the function
-   */
-    size_t dataReceive(std::shared_ptr<TcpRxConnection> connection, const char *data, size_t bytes_received);
+    void txPriorityReceive (std::shared_ptr<TcpConnection> connection,
+                            const char *data,
+                            size_t bytes_received,
+                            const boost::system::error_code &error);
+    /** callback function for receiving data asynchronously from the socket
+    @param connection pointer to the connection
+    @param data the pointer to the data
+    @param bytes_received the length of the received data
+    @return a the number of bytes used by the function
+    */
+    size_t dataReceive (std::shared_ptr<TcpRxConnection> connection, const char *data, size_t bytes_received);
 
-    bool commErrorHandler(std::shared_ptr<TcpRxConnection> connection, const boost::system::error_code& error);
-  //  bool errorHandle()
-public:
-	/** get the port number of the comms object to push message to*/
-	int getPort() const { return PortNumber; };
+    bool commErrorHandler (std::shared_ptr<TcpRxConnection> connection, const boost::system::error_code &error);
+    //  bool errorHandle()
+  public:
+    /** get the port number of the comms object to push message to*/
+    int getPort () const { return PortNumber; };
 
-	std::string getAddress() const;
+    std::string getAddress () const;
 };
 
-
-} // namespace helics
-
-#endif /* _HELICS_UDP_COMMS_ */
-
+}  // namespace tcp
+}  // namespace helics

--- a/src/helics/core/tcp/TcpCore.cpp
+++ b/src/helics/core/tcp/TcpCore.cpp
@@ -13,6 +13,7 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 
 namespace helics
 {
+namespace tcp {
 TcpCore::TcpCore () noexcept {}
 
 TcpCore::~TcpCore () = default;
@@ -61,4 +62,5 @@ std::string TcpCore::getAddress () const
     return makePortAddress (netInfo.localInterface, netInfo.portNumber);
 }
 
+} // namespace tcp
 }  // namespace helics

--- a/src/helics/core/tcp/TcpCore.h
+++ b/src/helics/core/tcp/TcpCore.h
@@ -1,41 +1,39 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
-This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
+This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
+Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
+Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
 */
-#ifndef _HELICS_TCP_CORE_
-#define _HELICS_TCP_CORE_
 #pragma once
 
 #include "../CommonCore.hpp"
 #include "../CommsBroker.hpp"
 #include "../NetworkBrokerData.hpp"
-namespace helics {
-
+namespace helics
+{
+namespace tcp
+{
 class TcpComms;
 /** implementation for the core that uses tcp messages to communicate*/
-class TcpCore final: public CommsBroker<TcpComms,CommonCore> {
+class TcpCore final : public CommsBroker<TcpComms, CommonCore>
+{
+  public:
+    /** default constructor*/
+    TcpCore () noexcept;
+    TcpCore (const std::string &core_name);
+    ~TcpCore ();
+    virtual void initializeFromArgs (int argc, const char *const *argv) override;
 
-public:
-	/** default constructor*/
-  TcpCore() noexcept;
-  TcpCore(const std::string &core_name);
-  ~TcpCore();
-  virtual void initializeFromArgs (int argc, const char * const *argv) override;
-         
-public:
-	virtual std::string getAddress() const override;
-private:
-	
-    NetworkBrokerData netInfo{ NetworkBrokerData::interface_type::tcp }; //!< structure containing the networking information
-	virtual bool brokerConnect() override;
- 
+  public:
+    virtual std::string getAddress () const override;
+
+  private:
+    NetworkBrokerData netInfo{
+      NetworkBrokerData::interface_type::tcp};  //!< structure containing the networking information
+    virtual bool brokerConnect () override;
 };
 
-
-} // namespace helics
- 
-#endif /* _HELICS_TCP_CORE_ */
+}  // namespace tcp
+}  // namespace helics

--- a/src/helics/core/tcp/TcpHelperClasses.cpp
+++ b/src/helics/core/tcp/TcpHelperClasses.cpp
@@ -1,18 +1,20 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 
 #include "TcpHelperClasses.h"
 #include <iostream>
 #include <thread>
 
+namespace helics
+{
+namespace tcp
+{
 using boost::asio::ip::tcp;
 
 void TcpRxConnection::start ()
@@ -259,3 +261,6 @@ void TcpServer::close ()
     }
     connections.clear ();
 }
+
+} //namespace tcp
+} // namespace helics

--- a/src/helics/core/tcp/TcpHelperClasses.h
+++ b/src/helics/core/tcp/TcpHelperClasses.h
@@ -1,113 +1,102 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
-This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
+This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
+Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
+Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
 */
-#ifndef _HELICS_TCP_HELPER_CLASSES_
-#define _HELICS_TCP_HELPER_CLASSES_
 #pragma once
 
-
-#include <boost/asio/ip/tcp.hpp>
-#include <boost/asio/io_service.hpp>
-#include <memory>
 #include <functional>
+#include <memory>
 #include <string>
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/ip/tcp.hpp>
 
-/** tcp socket generation for a receiving server*/
-class TcpRxConnection
-    : public std::enable_shared_from_this<TcpRxConnection>
+namespace helics
 {
-public:
+namespace tcp
+{
+/** tcp socket generation for a receiving server*/
+class TcpRxConnection : public std::enable_shared_from_this<TcpRxConnection>
+{
+  public:
     typedef std::shared_ptr<TcpRxConnection> pointer;
 
-    static pointer create(boost::asio::io_service& io_service, size_t bufferSize)
+    static pointer create (boost::asio::io_service &io_service, size_t bufferSize)
     {
-        return pointer(new TcpRxConnection(io_service,bufferSize));
+        return pointer (new TcpRxConnection (io_service, bufferSize));
     }
 
-    boost::asio::ip::tcp::socket& socket()
-    {
-        return socket_;
-    }
-    void start();
-    void stop()
-    {
-        socket_.cancel();
-    }
+    boost::asio::ip::tcp::socket &socket () { return socket_; }
+    void start ();
+    void stop () { socket_.cancel (); }
 
-    void close();
+    void close ();
 
-    void setDataCall(std::function<size_t (TcpRxConnection::pointer,const char *, size_t)> dataFunc)
+    void setDataCall (std::function<size_t (TcpRxConnection::pointer, const char *, size_t)> dataFunc)
     {
-        dataCall = std::move(dataFunc);
+        dataCall = std::move (dataFunc);
     }
-    void setErrorCall(std::function<bool(TcpRxConnection::pointer, const boost::system::error_code&)> errorFunc)
+    void setErrorCall (std::function<bool(TcpRxConnection::pointer, const boost::system::error_code &)> errorFunc)
     {
-        errorCall = std::move(errorFunc);
+        errorCall = std::move (errorFunc);
     }
 
     /** send raw data
     @throws boost::system::system_error on failure*/
-    void send(const void *buffer, size_t dataLength);
+    void send (const void *buffer, size_t dataLength);
     /** send a string
     @throws boost::system::system_error on failure*/
-    void send(const std::string &dataString);
+    void send (const std::string &dataString);
 
     int index = 0;
-private:
-    TcpRxConnection(boost::asio::io_service& io_service, size_t bufferSize)
-        : socket_(io_service), data(bufferSize)
+
+  private:
+    TcpRxConnection (boost::asio::io_service &io_service, size_t bufferSize)
+        : socket_ (io_service), data (bufferSize)
     {
     }
 
-    void handle_read(const boost::system::error_code &error,
-        size_t bytes_transferred);
-    std::atomic<size_t> residBufferSize{ 0 };
+    void handle_read (const boost::system::error_code &error, size_t bytes_transferred);
+    std::atomic<size_t> residBufferSize{0};
     boost::asio::ip::tcp::socket socket_;
     std::vector<char> data;
-   
-    std::atomic<bool> disconnected{ false };
+
+    std::atomic<bool> disconnected{false};
     std::function<size_t (TcpRxConnection::pointer, const char *, size_t)> dataCall;
-    std::function<bool(TcpRxConnection::pointer, const boost::system::error_code&)> errorCall;
-    std::atomic<bool> receiving{ false };
+    std::function<bool(TcpRxConnection::pointer, const boost::system::error_code &)> errorCall;
+    std::atomic<bool> receiving{false};
 };
 
-
 /** tcp socket connection for connecting to a server*/
-class TcpConnection
-    : public std::enable_shared_from_this<TcpConnection>
+class TcpConnection : public std::enable_shared_from_this<TcpConnection>
 {
-public:
+  public:
     typedef std::shared_ptr<TcpConnection> pointer;
 
-    static pointer create(boost::asio::io_service& io_service, const std::string &connection, const std::string &port, size_t bufferSize = 10192);
+    static pointer create (boost::asio::io_service &io_service,
+                           const std::string &connection,
+                           const std::string &port,
+                           size_t bufferSize = 10192);
 
-    boost::asio::ip::tcp::socket& socket()
-    {
-        return socket_;
-    }
-    void cancel()
-    {
-        socket_.cancel();
-    }
+    boost::asio::ip::tcp::socket &socket () { return socket_; }
+    void cancel () { socket_.cancel (); }
     /** close the socket connection
     @param*/
-    void close();
+    void close ();
     /** send raw data
     @throws boost::system::system_error on failure*/
-    void send(const void *buffer, size_t dataLength);
+    void send (const void *buffer, size_t dataLength);
     /** send a string
     @throws boost::system::system_error on failure*/
-    void send(const std::string &dataString);
+    void send (const std::string &dataString);
     /** do a blocking receive on the socket
     @throw boost::system::system_error on failure
     @return the number of bytes received
     */
-    size_t receive(void *buffer, size_t maxDataSize);
+    size_t receive (void *buffer, size_t maxDataSize);
 
     /**perform an asynchronous send operation
     @param buffer the data to send
@@ -115,12 +104,12 @@ public:
     @param callback a callback function of the form void handler(
   const boost::system::error_code& error, // Result of operation.
   std::size_t bytes_transferred           // Number of bytes received.
-); 
+);
 */
-    template<typename Process>
-    void send_async(const void *buffer, size_t dataLength, Process callback)
+    template <typename Process>
+    void send_async (const void *buffer, size_t dataLength, Process callback)
     {
-        socket_.async_send(boost::asio::buffer(buffer, dataLength), callback);
+        socket_.async_send (boost::asio::buffer (buffer, dataLength), callback);
     }
 
     /**perform an asynchronous receive operation
@@ -131,10 +120,10 @@ public:
     std::size_t bytes_transferred           // Number of bytes received.
     );
     */
-    template<typename Process>
-    void async_receive(void *buffer, size_t dataLength, Process callback)
+    template <typename Process>
+    void async_receive (void *buffer, size_t dataLength, Process callback)
     {
-        socket_.async_receive(boost::asio::buffer(buffer, dataLength), callback);
+        socket_.async_receive (boost::asio::buffer (buffer, dataLength), callback);
     }
 
     /**perform an asynchronous receive operation
@@ -145,76 +134,85 @@ public:
     std::size_t bytes_transferred           // Number of bytes received.
     );
     */
-    void async_receive(std::function<void(TcpConnection::pointer, const char *, size_t, const boost::system::error_code &error)> callback)
+    void async_receive (
+      std::function<void(TcpConnection::pointer, const char *, size_t, const boost::system::error_code &error)>
+        callback)
     {
-        socket_.async_receive(boost::asio::buffer(data, data.size()),
-            [connection = shared_from_this(),callback](const boost::system::error_code &error,
-                size_t bytes_transferred) {
-            connection->handle_read(bytes_transferred, error, callback);
-        });
+        socket_.async_receive (boost::asio::buffer (data, data.size ()),
+                               [connection = shared_from_this (), callback](const boost::system::error_code &error,
+                                                                            size_t bytes_transferred) {
+                                   connection->handle_read (bytes_transferred, error, callback);
+                               });
     }
-private:
-    void handle_read(size_t message_size, const boost::system::error_code &error, std::function<void(TcpConnection::pointer, const char *, size_t, const boost::system::error_code &error)> callback)
+
+  private:
+    void handle_read (
+      size_t message_size,
+      const boost::system::error_code &error,
+      std::function<void(TcpConnection::pointer, const char *, size_t, const boost::system::error_code &error)>
+        callback)
     {
-        callback(shared_from_this(), data.data(), message_size, error);
+        callback (shared_from_this (), data.data (), message_size, error);
     }
-public:
+
+  public:
     /** check if the socket has finished the connection process*/
-    bool isConnected() const
-    {
-        return connected.load();
-    }
+    bool isConnected () const { return connected.load (); }
     /** wait until the socket has finished the connection process
     @param timeOut the number of ms to wait for the connection process to finish (-1) for no limit
     @return 0 if connected, -1 if the timeout was reached, -2 if error
     */
-    int waitUntilConnected(int timeOut);
-private:
-    TcpConnection(boost::asio::io_service& io_service, const std::string &connection, const std::string &port, size_t bufferSize);
+    int waitUntilConnected (int timeOut);
+
+  private:
+    TcpConnection (boost::asio::io_service &io_service,
+                   const std::string &connection,
+                   const std::string &port,
+                   size_t bufferSize);
 
     boost::asio::ip::tcp::socket socket_;
-    std::atomic<bool> connected{ false };  //!< flag indicating connectivity
+    std::atomic<bool> connected{false};  //!< flag indicating connectivity
     std::vector<char> data;
 
-    void connect_handler(const boost::system::error_code &error);
-
+    void connect_handler (const boost::system::error_code &error);
 };
 
 /** helper class for a server*/
 
 class TcpServer
 {
-public:
-    TcpServer(boost::asio::io_service& io_service, int PortNum, int nominalBufferSize=10192)
-        : acceptor_(io_service, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), PortNum)),bufferSize(nominalBufferSize)
+  public:
+    TcpServer (boost::asio::io_service &io_service, int PortNum, int nominalBufferSize = 10192)
+        : acceptor_ (io_service, boost::asio::ip::tcp::endpoint (boost::asio::ip::tcp::v4 (), PortNum)),
+          bufferSize (nominalBufferSize)
     {
-
-    }
-     
-    void stop();
-
-    void start();
-
-    void close();
-
-    void setDataCall(std::function<size_t(TcpRxConnection::pointer, const char *, size_t)> dataFunc)
-    {
-        dataCall = std::move(dataFunc);
-    }
-    void setErrorCall(std::function<bool(TcpRxConnection::pointer, const boost::system::error_code&)> errorFunc)
-    {
-        errorCall = std::move(errorFunc);
     }
 
-private:
-    void handle_accept(TcpRxConnection::pointer new_connection,
-        const boost::system::error_code& error);
+    void stop ();
+
+    void start ();
+
+    void close ();
+
+    void setDataCall (std::function<size_t (TcpRxConnection::pointer, const char *, size_t)> dataFunc)
+    {
+        dataCall = std::move (dataFunc);
+    }
+    void setErrorCall (std::function<bool(TcpRxConnection::pointer, const boost::system::error_code &)> errorFunc)
+    {
+        errorCall = std::move (errorFunc);
+    }
+
+  private:
+    void handle_accept (TcpRxConnection::pointer new_connection, const boost::system::error_code &error);
 
     boost::asio::ip::tcp::acceptor acceptor_;
-    
+
     size_t bufferSize;
-    std::function<size_t(TcpRxConnection::pointer, const char *, size_t)> dataCall;
-    std::function<bool(TcpRxConnection::pointer, const boost::system::error_code& error)> errorCall;
+    std::function<size_t (TcpRxConnection::pointer, const char *, size_t)> dataCall;
+    std::function<bool(TcpRxConnection::pointer, const boost::system::error_code &error)> errorCall;
     std::vector<std::shared_ptr<TcpRxConnection>> connections;
 };
-#endif /* _HELICS_TCP_HELPER_CLASSES_*/
+
+}  // namespace tcp
+}  // namespace helics

--- a/src/helics/core/udp/UdpBroker.cpp
+++ b/src/helics/core/udp/UdpBroker.cpp
@@ -1,18 +1,18 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
+
 #include "UdpBroker.h"
 #include "UdpComms.h"
 
 namespace helics
 {
+namespace udp {
 UdpBroker::UdpBroker (bool rootBroker) noexcept : CommsBroker (rootBroker) {}
 
 UdpBroker::UdpBroker (const std::string &broker_name) : CommsBroker (broker_name) {}
@@ -70,4 +70,5 @@ std::string UdpBroker::getAddress () const
     }
     return makePortAddress (netInfo.localInterface, netInfo.portNumber);
 }
+} // namespace udp
 }  // namespace helics

--- a/src/helics/core/udp/UdpBroker.h
+++ b/src/helics/core/udp/UdpBroker.h
@@ -15,6 +15,8 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 
 namespace helics
 {
+namespace udp
+{
 class UdpComms;
 
 class UdpBroker final : public CommsBroker<UdpComms, CoreBroker>
@@ -37,4 +39,6 @@ class UdpBroker final : public CommsBroker<UdpComms, CoreBroker>
     NetworkBrokerData netInfo{
       NetworkBrokerData::interface_type::udp};  //!< structure containing the networking information
 };
-}
+
+}  // namespace udp
+}  // namespace helics

--- a/src/helics/core/udp/UdpComms.cpp
+++ b/src/helics/core/udp/UdpComms.cpp
@@ -22,6 +22,7 @@ static const int DEFAULT_UDP_BROKER_PORT_NUMBER = 23901;
 
 namespace helics
 {
+namespace udp {
 using boost::asio::ip::udp;
 UdpComms::UdpComms ()
 {
@@ -509,4 +510,7 @@ void UdpComms::closeReceiver ()
 }
 
 std::string UdpComms::getAddress () const { return makePortAddress (localTarget_, PortNumber); }
+
+} // namespace udp
+
 }  // namespace helics

--- a/src/helics/core/udp/UdpComms.h
+++ b/src/helics/core/udp/UdpComms.h
@@ -33,6 +33,7 @@ class io_service;
 #endif
 namespace helics
 {
+namespace udp {
 /** implementation for the communication interface that uses ZMQ messages to communicate*/
 class UdpComms final : public CommsInterface
 {
@@ -74,4 +75,5 @@ class UdpComms final : public CommsInterface
     std::string getAddress () const;
 };
 
+} // namespace udp
 }  // namespace helics

--- a/src/helics/core/udp/UdpCore.cpp
+++ b/src/helics/core/udp/UdpCore.cpp
@@ -13,6 +13,7 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 
 namespace helics
 {
+namespace udp {
 UdpCore::UdpCore () noexcept {}
 
 UdpCore::~UdpCore () = default;
@@ -60,4 +61,5 @@ std::string UdpCore::getAddress () const
     return makePortAddress (netInfo.localInterface, netInfo.portNumber);
 }
 
+} // namespace udp
 }  // namespace helics

--- a/src/helics/core/udp/UdpCore.h
+++ b/src/helics/core/udp/UdpCore.h
@@ -13,24 +13,25 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 #include "../NetworkBrokerData.hpp"
 namespace helics
 {
+namespace udp {
 class UdpComms;
 /** implementation for the core that uses udp messages to communicate*/
 class UdpCore final : public CommsBroker<UdpComms, CommonCore>
 {
-  public:
+public:
     /** default constructor*/
-    UdpCore () noexcept;
-    UdpCore (const std::string &core_name);
-    ~UdpCore ();
-    virtual void initializeFromArgs (int argc, const char *const *argv) override;
+    UdpCore() noexcept;
+    UdpCore(const std::string &core_name);
+    ~UdpCore();
+    virtual void initializeFromArgs(int argc, const char *const *argv) override;
 
-  public:
-    virtual std::string getAddress () const override;
+public:
+    virtual std::string getAddress() const override;
 
-  private:
+private:
     NetworkBrokerData netInfo{
-      NetworkBrokerData::interface_type::udp};  //!< structure containing the networking information
-    virtual bool brokerConnect () override;
+      NetworkBrokerData::interface_type::udp };  //!< structure containing the networking information
+    virtual bool brokerConnect() override;
 };
-
+} // namespace udp
 }  // namespace helics

--- a/src/helics/core/zmq/ZmqBroker.cpp
+++ b/src/helics/core/zmq/ZmqBroker.cpp
@@ -12,6 +12,7 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 
 namespace helics
 {
+namespace zeromq {
 ZmqBroker::ZmqBroker (bool rootBroker) noexcept : CommsBroker (rootBroker) {}
 
 ZmqBroker::ZmqBroker (const std::string &broker_name) : CommsBroker (broker_name) {}
@@ -76,4 +77,6 @@ std::string ZmqBroker::getAddress () const
         return makePortAddress (netInfo.localInterface, netInfo.portNumber);
     }
 }
+
+} // namespace zeromq
 }  // namespace helics

--- a/src/helics/core/zmq/ZmqBroker.h
+++ b/src/helics/core/zmq/ZmqBroker.h
@@ -16,7 +16,7 @@ This software was co-developed by Pacific Northwest National Laboratory, operate
 
 namespace helics
 {
-
+namespace zeromq {
 class ZmqComms;
 
 class ZmqBroker final:public CommsBroker<ZmqComms,CoreBroker>
@@ -39,5 +39,7 @@ private:
     NetworkBrokerData netInfo{ NetworkBrokerData::interface_type::tcp }; //!< container for the network connection information
 
 };
-}
+
+} // namespace zeromq
+} // namespace helics
 #endif

--- a/src/helics/core/zmq/ZmqComms.cpp
+++ b/src/helics/core/zmq/ZmqComms.cpp
@@ -27,6 +27,7 @@ static const int DEFAULT_BROKER_REP_PORT_NUMBER = 23404;
 
 namespace helics
 {
+namespace zeromq {
 ZmqComms::ZmqComms (const std::string &brokerTarget, const std::string &localTarget)
     : CommsInterface (brokerTarget, localTarget)
 {
@@ -779,4 +780,6 @@ std::string ZmqComms::getPushAddress () const
         return makePortAddress (localTarget_, pullPortNumber);
     }
 }
+
+} // namespace zeromq
 }  // namespace helics

--- a/src/helics/core/zmq/ZmqComms.h
+++ b/src/helics/core/zmq/ZmqComms.h
@@ -21,7 +21,7 @@ class message_t;
 class socket_t;
 }
 namespace helics {
-
+namespace zeromq {
 /** implementation for the communication interface that uses ZMQ messages to communicate*/
 class ZmqComms final:public CommsInterface {
 
@@ -66,7 +66,7 @@ public:
     std::string getPushAddress() const;
 };
 
-
+} // namespace zeromq
 } // namespace helics
 
 #endif /* _HELICS_IPC_COMMS_ */

--- a/src/helics/core/zmq/ZmqCore.cpp
+++ b/src/helics/core/zmq/ZmqCore.cpp
@@ -13,6 +13,7 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 
 namespace helics
 {
+namespace zeromq {
 ZmqCore::ZmqCore () noexcept {}
 
 ZmqCore::~ZmqCore () = default;
@@ -68,4 +69,5 @@ std::string ZmqCore::getAddress () const
     }
 }
 
+} // namespace zeromq
 }  // namespace helics

--- a/src/helics/core/zmq/ZmqCore.h
+++ b/src/helics/core/zmq/ZmqCore.h
@@ -14,7 +14,7 @@ This software was co-developed by Pacific Northwest National Laboratory, operate
 #include "../CommsBroker.hpp"
 #include "../NetworkBrokerData.hpp"
 namespace helics {
-
+namespace zeromq {
 class ZmqComms;
 /** implementation for the core that uses zmq messages to communicate*/
 class ZmqCore final: public CommsBroker<ZmqComms,CommonCore> {
@@ -38,7 +38,7 @@ private:
  
 };
 
-
+} // namespace zeromq
 } // namespace helics
  
 #endif /* _HELICS_ZEROMQ_CORE_ */

--- a/src/helics/core/zmq/ZmqRequestSets.cpp
+++ b/src/helics/core/zmq/ZmqRequestSets.cpp
@@ -1,12 +1,10 @@
 /*
-
 Copyright (C) 2017-2018, Battelle Memorial Institute
 All rights reserved.
 
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 
 #include "ZmqRequestSets.h"
@@ -15,7 +13,8 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 
 namespace helics
 {
-ZmqRequestSets::ZmqRequestSets () { ctx = zmqContextManager::getContextPointer (); }
+namespace zeromq {
+ZmqRequestSets::ZmqRequestSets (): ctx(zmqContextManager::getContextPointer()) {}
 void ZmqRequestSets::addRoutes (int routeNumber, const std::string &routeInfo)
 {
     auto zsock = std::make_unique<zmq::socket_t> (ctx->getContext (), ZMQ_REQ);
@@ -178,5 +177,5 @@ private:
     std::queue<std::pair<int, ActionMessage>> waiting_messages;
     std::queue<ActionMessage> Responses;
     */
-
+} // namespace zeromq
 }  // namespace helics

--- a/src/helics/core/zmq/ZmqRequestSets.h
+++ b/src/helics/core/zmq/ZmqRequestSets.h
@@ -22,10 +22,11 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 
 namespace helics
 {
+namespace zeromq {
 /**helper class to manage REQ sockets that are awaiting a response*/
 class waitingResponse
 {
-  public:
+public:
     int route; //!< the route identifier for the socket
     std::uint16_t loops = 0; //!< the number of loops
     bool waiting = false;	//!< whether the response is waiting
@@ -40,41 +41,42 @@ safe
 */
 class ZmqRequestSets
 {
-  public:
+public:
     /** constructor*/
-    ZmqRequestSets ();
+    ZmqRequestSets();
     /** add a route to the request set*/
-    void addRoutes (int routeNumber, const std::string &routeInfo);
+    void addRoutes(int routeNumber, const std::string &routeInfo);
     /** transmit a command to a specific route number*/
-    bool transmit (int routeNumber, const ActionMessage &command);
+    bool transmit(int routeNumber, const ActionMessage &command);
     /** check if the request set is waiting on any on responses*/
-    bool waiting () const;
+    bool waiting() const;
     /** check for messages with a 0 second timeout
     @return the number of message waiting to be received*/
-    int checkForMessages ();
+    int checkForMessages();
     /** check for messages with an explicit timeout
     @return the number of message waiting to be received*/
-    int checkForMessages (std::chrono::milliseconds timeout);
+    int checkForMessages(std::chrono::milliseconds timeout);
     /** check if there are any waiting message without scanning the sockets*/
-    bool hasMessages () const;
+    bool hasMessages() const;
     /** get any messages that have been received*/
-    stx::optional<ActionMessage> getMessage ();
+    stx::optional<ActionMessage> getMessage();
     /** close all the sockets*/
     void close();
-  private:
+private:
     /** check to send any messages that have been delayed waiting for a previous send*/
-    void SendDelayedMessages ();
+    void SendDelayedMessages();
 
-  private:
+private:
     std::map<int, std::unique_ptr<zmq::socket_t>> routes;  //!< map of all the routes
     std::map<int, bool> routes_waiting;  //!< routes that are waiting to be sent
     std::vector<zmq::pollitem_t> active_routes;  //!< active routes for ZMQ poller
     std::vector<waitingResponse> active_messages;  //!< more information about waiting messages
     std::vector<std::pair<int, ActionMessage>> waiting_messages;  //!< messages that are queued up to send
     std::deque<ActionMessage>
-      Responses;  //!< message that have been received and are waiting to be sent to the holder
+        Responses;  //!< message that have been received and are waiting to be sent to the holder
     std::shared_ptr<zmqContextManager> ctx;  //!< the ZMQ context manager
 };
+} // namespace zeromq
 }  // namespace helics
 
 #endif

--- a/src/helics/cpp98/Federate.hpp
+++ b/src/helics/cpp98/Federate.hpp
@@ -155,7 +155,7 @@ class Federate
 {
   public:
     // Default constructor, not meant to be used
-    Federate () {};
+    Federate ():fed(nullptr),exec_async_iterate(false) {};
 
     virtual ~Federate ()
     {

--- a/src/helics/cpp98/helics.hpp
+++ b/src/helics/cpp98/helics.hpp
@@ -5,8 +5,8 @@ All rights reserved.
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
+
 #ifndef _HELICS_CPP98_API_
 #define _HELICS_CPP98_API_
 #pragma once

--- a/src/helics/flag-definitions.h
+++ b/src/helics/flag-definitions.h
@@ -5,7 +5,6 @@ All rights reserved.
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 #ifndef _HELICS_FLAG_DEFINITIONS_
 #define _HELICS_FLAG_DEFINITIONS_
@@ -14,14 +13,22 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 @details define statements for flag codes 
 */
 
+/** flag indicating that a federate is observe only*/
 #define OBSERVER_FLAG 0
+/** flag indicating that a federate can only return requested times*/
 #define UNINTERRUPTIBLE_FLAG 1
+/** flag indicating that a federate is a signal generator only*/
 #define SOURCE_ONLY_FLAG 2
+/** flag indicating a federate should only transmit values if they have changed(binary equivalence)*/
 #define ONLY_TRANSMIT_ON_CHANGE_FLAG 3
+/** flag indicating a federate should only trigger an update if a value has changed (binary equivalence)*/
 #define ONLY_UPDATE_ON_CHANGE_FLAG 4
+/** flag indicating a federate should only grant time if all other federates have already passed the requested time*/
 #define WAIT_FOR_CURRENT_TIME_UPDATE_FLAG 5
 
+/** flag indicating that a federate has rollback capability*/
 #define ROLLBACK_FLAG 8
+/** flag indicating that a federate performs forward computation and does internal rollback*/
 #define FORWARD_COMPUTE_FLAG 9
 
 /** used to delay a core from entering initialization mode even if it would otherwise be ready*/

--- a/src/helics/shared_api_library/helicsExport.cpp
+++ b/src/helics/shared_api_library/helicsExport.cpp
@@ -27,9 +27,8 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 #include "../common/zmqContextManager.h"
 #endif
 
-static const std::string versionStr (helics::versionString ());
 
-const char *helicsGetVersion (void) { return versionStr.c_str (); }
+const char *helicsGetVersion(void) { return helics::versionString; }
 
 helics_bool_t helicsIsCoreTypeAvailable (const char *type)
 {
@@ -707,6 +706,7 @@ MasterObjectHolder::~MasterObjectHolder()
         zmqContextManager::getContext().close();
     }
 #endif
+    helics::LoggingCore::setFastShutdown();
     deleteAll();
     //std::cout << "end of master Object Holder destructor" << std::endl;
 }

--- a/tests/helics/application_api/MessageFederateTests.cpp
+++ b/tests/helics/application_api/MessageFederateTests.cpp
@@ -620,8 +620,8 @@ class pingpongFed
     int pings = 0;  //!< the number of pings received
     int pongs = 0;  //!< the number of pongs received
   public:
-    pingpongFed (std::string fname, helics::Time tDelta, helics::core_type ctype)
-        : delta (tDelta), name (std::move (fname)), coreType (ctype)
+    pingpongFed (const std::string &fname, helics::Time tDelta, helics::core_type ctype)
+        : delta (tDelta), name (fname), coreType (ctype)
     {
         if (delta <= 0.0)
         {

--- a/tests/helics/application_api/testFixtures.cpp
+++ b/tests/helics/application_api/testFixtures.cpp
@@ -5,7 +5,6 @@ All rights reserved.
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 #include "testFixtures.hpp"
 #include <boost/test/unit_test.hpp>

--- a/tests/helics/apps/exeTestHelper.cpp
+++ b/tests/helics/apps/exeTestHelper.cpp
@@ -1,4 +1,3 @@
-/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil;  eval: (c-set-offset 'innamespace 0); -*- */
 /*
  * LLNS Copyright Start
  * Copyright (c) 2016, Lawrence Livermore National Security

--- a/tests/helics/apps/exeTestHelper.h
+++ b/tests/helics/apps/exeTestHelper.h
@@ -1,5 +1,3 @@
-#pragma once
-/* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil;  eval: (c-set-offset 'innamespace 0); -*- */
 /*
  * LLNS Copyright Start
  * Copyright (c) 2016, Lawrence Livermore National Security
@@ -14,7 +12,7 @@
 
 #ifndef EXE_HELPER_HEADER_
 #define EXE_HELPER_HEADER_
-
+#pragma once
 #include <future>
 #include <string>
 
@@ -23,7 +21,7 @@ class exeTestRunner
 {
   private:
     std::string exeString;
-    bool active;
+    bool active=false;
     static int counter;
     std::string outFile;
 

--- a/tests/helics/apps/player_tests.cpp
+++ b/tests/helics/apps/player_tests.cpp
@@ -255,6 +255,10 @@ BOOST_REQUIRE(brokerExe.isActive());
     retTime = vfed.requestTime (5);
     BOOST_CHECK_EQUAL (retTime, 5.0);
     vfed.finalize ();
+    auto out2 = res2.get();
+    res.get();
+   // out = 0;
+
 }
 
 BOOST_AUTO_TEST_CASE (simple_player_testjson)

--- a/tests/helics/core/IPCcore_tests.cpp
+++ b/tests/helics/core/IPCcore_tests.cpp
@@ -34,9 +34,9 @@ BOOST_AUTO_TEST_CASE (ipccomms_broker_test)
     std::atomic<int> counter{0};
     std::string brokerLoc = "brokerIPC";
     std::string localLoc = "localIPC";
-    helics::IpcComms comm (localLoc, brokerLoc);
+    helics::ipc::IpcComms comm (localLoc, brokerLoc);
 
-    helics::ownedQueue mq;
+    helics::ipc::ownedQueue mq;
     bool mqConn = mq.connect (brokerLoc, 1024, 1024);
     BOOST_REQUIRE (mqConn);
 
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE (ipccomms_rx_test)
     helics::ActionMessage act;
     std::string brokerLoc = "";
     std::string localLoc = "localIPC";
-    helics::IpcComms comm (localLoc, brokerLoc);
+    helics::ipc::IpcComms comm (localLoc, brokerLoc);
 
     comm.setCallback ([&counter, &act](helics::ActionMessage m) {
         ++counter;
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE (ipccomms_rx_test)
 
     bool connected = comm.connect ();
     BOOST_REQUIRE (connected);
-    helics::sendToQueue mq;
+    helics::ipc::sendToQueue mq;
     mq.connect (localLoc, true, 2);
 
     helics::ActionMessage cmd (helics::CMD_ACK);
@@ -90,8 +90,8 @@ BOOST_AUTO_TEST_CASE (ipcComm_transmit_through)
     helics::ActionMessage act;
     helics::ActionMessage act2;
 
-    helics::IpcComms comm (localLoc, brokerLoc);
-    helics::IpcComms comm2 (brokerLoc, "");
+    helics::ipc::IpcComms comm (localLoc, brokerLoc);
+    helics::ipc::IpcComms comm2 (brokerLoc, "");
 
     comm.setCallback ([&counter, &act](helics::ActionMessage m) {
         ++counter;
@@ -139,9 +139,9 @@ BOOST_AUTO_TEST_CASE (ipcComm_transmit_add_route)
     helics::ActionMessage act2;
     helics::ActionMessage act3;
 
-    helics::IpcComms comm (localLoc, brokerLoc);
-    helics::IpcComms comm2 (brokerLoc, "");
-    helics::IpcComms comm3 (localLocB, brokerLoc);
+    helics::ipc::IpcComms comm (localLoc, brokerLoc);
+    helics::ipc::IpcComms comm2 (brokerLoc, "");
+    helics::ipc::IpcComms comm3 (localLocB, brokerLoc);
 
     comm.setCallback ([&counter, &act](helics::ActionMessage m) {
         ++counter;
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE (ipccore_initialization_test)
     BOOST_REQUIRE (core != nullptr);
     BOOST_CHECK (core->isInitialized ());
 
-    helics::ownedQueue mq;
+    helics::ipc::ownedQueue mq;
     bool mqConn = mq.connect ("testBroker", 1024, 1024);
     BOOST_REQUIRE (mqConn);
 

--- a/tests/helics/core/TcpCore-tests.cpp
+++ b/tests/helics/core/TcpCore-tests.cpp
@@ -5,7 +5,6 @@ All rights reserved.
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 #include <boost/test/unit_test.hpp>
 
@@ -38,10 +37,10 @@ BOOST_AUTO_TEST_CASE (test_tcpServerConnections1)
     std::string host = "localhost";
 
     auto srv = AsioServiceManager::getServicePointer ();
-    TcpServer server (srv->getBaseService (), TCP_BROKER_PORT);
+    helics::tcp::TcpServer server (srv->getBaseService (), TCP_BROKER_PORT);
     auto serviceLoop = srv->runServiceLoop ();
     std::vector<char> data (1024);
-    auto dataCheck = [&counter](TcpRxConnection::pointer, const char *datablock, size_t datasize) {
+    auto dataCheck = [&counter](helics::tcp::TcpRxConnection::pointer, const char *datablock, size_t datasize) {
         size_t used = 0;
         while (datasize - used >= 20)
         {
@@ -60,10 +59,10 @@ BOOST_AUTO_TEST_CASE (test_tcpServerConnections1)
     server.setDataCall (dataCheck);
     server.start ();
 
-    auto conn1 = TcpConnection::create (srv->getBaseService (), host, "24160", 1024);
-    auto conn2 = TcpConnection::create (srv->getBaseService (), host, "24160", 1024);
-    auto conn3 = TcpConnection::create (srv->getBaseService (), host, "24160", 1024);
-    auto conn4 = TcpConnection::create (srv->getBaseService (), host, "24160", 1024);
+    auto conn1 = helics::tcp::TcpConnection::create (srv->getBaseService (), host, "24160", 1024);
+    auto conn2 = helics::tcp::TcpConnection::create (srv->getBaseService (), host, "24160", 1024);
+    auto conn3 = helics::tcp::TcpConnection::create (srv->getBaseService (), host, "24160", 1024);
+    auto conn4 = helics::tcp::TcpConnection::create (srv->getBaseService (), host, "24160", 1024);
 
     auto res = conn1->waitUntilConnected (1000);
     BOOST_CHECK_EQUAL (res, 0);
@@ -74,7 +73,7 @@ BOOST_AUTO_TEST_CASE (test_tcpServerConnections1)
     res = conn4->waitUntilConnected (1000);
     BOOST_CHECK_EQUAL (res, 0);
 
-    auto transmitFunc = [](TcpConnection::pointer obj) {
+    auto transmitFunc = [](helics::tcp::TcpConnection::pointer obj) {
         std::vector<char> dataB (20);
         for (char ii = 0; ii < 50; ++ii)
         {
@@ -114,14 +113,14 @@ BOOST_AUTO_TEST_CASE (tcpComms_broker_test)
 {
     std::atomic<int> counter{0};
     std::string host = "localhost";
-    helics::TcpComms comm (host, host);
+    helics::tcp::TcpComms comm (host, host);
 
     auto srv = AsioServiceManager::getServicePointer ();
 
-    TcpServer server (srv->getBaseService (), TCP_BROKER_PORT);
+    helics::tcp::TcpServer server (srv->getBaseService (), TCP_BROKER_PORT);
     auto serviceLoop = srv->runServiceLoop ();
     std::vector<char> data (1024);
-    server.setDataCall ([&counter](TcpRxConnection::pointer, const char *, size_t data_avail) {
+    server.setDataCall ([&counter](helics::tcp::TcpRxConnection::pointer, const char *, size_t data_avail) {
         ++counter;
         return data_avail;
     });
@@ -155,13 +154,13 @@ BOOST_AUTO_TEST_CASE (tcpComms_broker_test_transmit)
     std::atomic<int> counter{0};
     std::atomic<size_t> len{0};
     std::string host = "localhost";
-    helics::TcpComms comm (host, host);
+    helics::tcp::TcpComms comm (host, host);
 
     auto srv = AsioServiceManager::getServicePointer ();
-    TcpServer server (srv->getBaseService (), TCP_BROKER_PORT);
+    helics::tcp::TcpServer server (srv->getBaseService (), TCP_BROKER_PORT);
     srv->runServiceLoop ();
     std::vector<char> data (1024);
-    server.setDataCall ([&data, &counter, &len](TcpRxConnection::pointer, const char *data_rec, size_t data_Size) {
+    server.setDataCall ([&data, &counter, &len](helics::tcp::TcpRxConnection::pointer, const char *data_rec, size_t data_Size) {
         std::copy (data_rec, data_rec + data_Size, data.begin ());
         len = data_Size;
         ++counter;
@@ -205,15 +204,15 @@ BOOST_AUTO_TEST_CASE (tcpComms_rx_test)
     std::atomic<size_t> len{0};
     helics::ActionMessage act;
     std::string host = "localhost";
-    helics::TcpComms comm (host, host);
+    helics::tcp::TcpComms comm (host, host);
     std::mutex actguard;
     auto srv = AsioServiceManager::getServicePointer ();
 
-    TcpServer server (srv->getBaseService (), TCP_BROKER_PORT);
+    helics::tcp::TcpServer server (srv->getBaseService (), TCP_BROKER_PORT);
     srv->runServiceLoop ();
     std::vector<char> data (1024);
     server.setDataCall (
-      [&data, &ServerCounter, &len](TcpRxConnection::pointer, const char *data_rec, size_t data_Size) {
+      [&data, &ServerCounter, &len](helics::tcp::TcpRxConnection::pointer, const char *data_rec, size_t data_Size) {
           std::copy (data_rec, data_rec + data_Size, data.begin ());
           len = data_Size;
           ++ServerCounter;
@@ -233,7 +232,7 @@ BOOST_AUTO_TEST_CASE (tcpComms_rx_test)
     bool connected = comm.connect ();
     BOOST_REQUIRE (connected);
 
-    auto txconn = TcpConnection::create (srv->getBaseService (), host, "24180", 1024);
+    auto txconn = helics::tcp::TcpConnection::create (srv->getBaseService (), host, "24180", 1024);
     auto res = txconn->waitUntilConnected (1000);
     BOOST_REQUIRE_EQUAL (res, 0);
 
@@ -261,8 +260,8 @@ BOOST_AUTO_TEST_CASE (tcpComm_transmit_through)
     helics::ActionMessage act2;
 
     std::string host = "localhost";
-    helics::TcpComms comm (host, host);
-    helics::TcpComms comm2 (host, "");
+    helics::tcp::TcpComms comm (host, host);
+    helics::tcp::TcpComms comm2 (host, "");
 
     comm.setBrokerPort (TCP_BROKER_PORT);
     comm.setName ("tests");
@@ -279,7 +278,7 @@ BOOST_AUTO_TEST_CASE (tcpComm_transmit_through)
         act2 = m;
     });
 
-    // need to launch the connection commands at the same time since they depend on eachother in this case
+    // need to launch the connection commands at the same time since they depend on each other in this case
     auto connected_fut = std::async (std::launch::async, [&comm] { return comm.connect (); });
 
     bool connected = comm2.connect ();
@@ -309,9 +308,9 @@ BOOST_AUTO_TEST_CASE (tcpComm_transmit_add_route)
     std::atomic<int> counter3{0};
 
     std::string host = "localhost";
-    helics::TcpComms comm (host, host);
-    helics::TcpComms comm2 (host, "");
-    helics::TcpComms comm3 (host, host);
+    helics::tcp::TcpComms comm (host, host);
+    helics::tcp::TcpComms comm2 (host, "");
+    helics::tcp::TcpComms comm3 (host, host);
 
     comm.setBrokerPort (TCP_BROKER_PORT);
     comm.setName ("tests");
@@ -399,11 +398,11 @@ BOOST_AUTO_TEST_CASE (tcpCore_initialization_test)
     BOOST_CHECK (core->isInitialized ());
     auto srv = AsioServiceManager::getServicePointer ();
 
-    TcpServer server (srv->getBaseService (), TCP_BROKER_PORT);
+    helics::tcp::TcpServer server (srv->getBaseService (), TCP_BROKER_PORT);
     srv->runServiceLoop ();
     std::vector<char> data (1024);
     std::atomic<size_t> len{0};
-    server.setDataCall ([&data, &counter, &len](TcpRxConnection::pointer, const char *data_rec, size_t data_Size) {
+    server.setDataCall ([&data, &counter, &len](helics::tcp::TcpRxConnection::pointer, const char *data_rec, size_t data_Size) {
         std::copy (data_rec, data_rec + data_Size, data.begin ());
         len = data_Size;
         ++counter;
@@ -460,7 +459,7 @@ BOOST_AUTO_TEST_CASE (tcpCore_core_broker_default_test)
     connected = core->connect ();
     BOOST_CHECK (connected);
 
-    auto ccore = static_cast<helics::TcpCore *> (core.get ());
+    auto ccore = static_cast<helics::tcp::TcpCore *> (core.get ());
     // this will test the automatic port allocation
     BOOST_CHECK_EQUAL (ccore->getAddress (), "localhost:24228");
     core->disconnect ();

--- a/tests/helics/core/TestCore-tests.cpp
+++ b/tests/helics/core/TestCore-tests.cpp
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE (testcore_initialization_test)
     std::string initializationString = std::string("4")+" --broker="+broker->getIdentifier();
     auto core = create (helics::core_type::TEST, initializationString);
 
-    auto Tcore = std::dynamic_pointer_cast<helics::TestCore>(core);
+    auto Tcore = std::dynamic_pointer_cast<helics::testcore::TestCore>(core);
 
     BOOST_REQUIRE (core);
     BOOST_REQUIRE(Tcore);
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE (testcore_messagefilter_callback_test)
     class TestOperator : public helics::FilterOperator
     {
       public:
-        TestOperator (const std::string &name) : filterName (name) {}
+        explicit TestOperator (const std::string &name) : filterName (name) {}
 
         std::unique_ptr<helics::Message> process (std::unique_ptr<helics::Message> msg) override
         {

--- a/tests/helics/core/UdpCore-tests.cpp
+++ b/tests/helics/core/UdpCore-tests.cpp
@@ -5,7 +5,6 @@ All rights reserved.
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
 #include <boost/test/unit_test.hpp>
 
@@ -34,7 +33,7 @@ BOOST_AUTO_TEST_CASE (udpComms_broker_test)
 {
     std::atomic<int> counter{0};
     std::string host = "localhost";
-    helics::UdpComms comm (host, host);
+    helics::udp::UdpComms comm (host, host);
 
     auto srv = AsioServiceManager::getServicePointer ();
 
@@ -70,7 +69,7 @@ BOOST_AUTO_TEST_CASE (udpComms_broker_test_transmit)
 {
     std::atomic<int> counter{0};
     std::string host = "localhost";
-    helics::UdpComms comm (host, host);
+    helics::udp::UdpComms comm (host, host);
 
     auto srv = AsioServiceManager::getServicePointer ();
 
@@ -104,7 +103,7 @@ BOOST_AUTO_TEST_CASE (udpComms_rx_test)
     std::atomic<int> counter{0};
     helics::ActionMessage act;
     std::string host = "localhost";
-    helics::UdpComms comm (host, host);
+    helics::udp::UdpComms comm (host, host);
 
     auto srv = AsioServiceManager::getServicePointer ();
 
@@ -149,8 +148,8 @@ BOOST_AUTO_TEST_CASE (udpComm_transmit_through)
     helics::ActionMessage act2;
 
     std::string host = "localhost";
-    helics::UdpComms comm (host, host);
-    helics::UdpComms comm2 (host, "");
+    helics::udp::UdpComms comm (host, host);
+    helics::udp::UdpComms comm2 (host, "");
 
     comm.setBrokerPort (UDP_BROKER_PORT);
     comm.setName ("tests");
@@ -197,9 +196,9 @@ BOOST_AUTO_TEST_CASE (udpComm_transmit_add_route)
     std::atomic<int> counter3{0};
 
     std::string host = "localhost";
-    helics::UdpComms comm (host, host);
-    helics::UdpComms comm2 (host, "");
-    helics::UdpComms comm3 (host, host);
+    helics::udp::UdpComms comm (host, host);
+    helics::udp::UdpComms comm2 (host, "");
+    helics::udp::UdpComms comm3 (host, host);
 
     comm.setBrokerPort (UDP_BROKER_PORT);
     comm.setName ("tests");
@@ -328,7 +327,7 @@ BOOST_AUTO_TEST_CASE (udpCore_core_broker_default_test)
     connected = core->connect ();
     BOOST_CHECK (connected);
 
-    auto ccore = static_cast<helics::UdpCore *> (core.get ());
+    auto ccore = static_cast<helics::udp::UdpCore *> (core.get ());
     // this will test the automatic port allocation
     BOOST_CHECK_EQUAL (ccore->getAddress (), "localhost:23964");
     core->disconnect ();

--- a/tests/helics/core/ZeromqCore-tests.cpp
+++ b/tests/helics/core/ZeromqCore-tests.cpp
@@ -28,12 +28,17 @@ BOOST_AUTO_TEST_SUITE (ZMQCore_tests)
 
 using helics::Core;
 const std::string defServer("tcp://127.0.0.1:23405");
+const std::string host = "tcp://127.0.0.1";
+
+const std::string defRoute1("tcp://127.0.0.1:23406");
+
+const std::string defRoute2("tcp://127.0.0.1:23407");
 
 BOOST_AUTO_TEST_CASE (zmqComms_broker_test)
 {
     std::atomic<int> counter{0};
-    std::string host = "tcp://127.0.0.1";
-    helics::ZmqComms comm (host, host);
+    
+    helics::zeromq::ZmqComms comm (host, host);
 
     auto ctx = zmqContextManager::getContextPointer ();
     zmq::socket_t repSocket (ctx->getContext (), ZMQ_REP);
@@ -61,21 +66,20 @@ BOOST_AUTO_TEST_CASE (zmqComms_broker_test)
 /** test the request set class with various scenarios*/
 BOOST_AUTO_TEST_CASE (zmqRequestSet_test1)
 {
-    std::string host = "tcp://127.0.0.1";
 
-    helics::ZmqRequestSets reqset;
+    helics::zeromq::ZmqRequestSets reqset;
 
     auto ctx = zmqContextManager::getContextPointer ();
     zmq::socket_t repSocket1 (ctx->getContext (), ZMQ_REP);
     repSocket1.bind (defServer);
     zmq::socket_t repSocket2 (ctx->getContext (), ZMQ_REP);
-    repSocket2.bind ("tcp://127.0.0.1:23406");
+    repSocket2.bind (defRoute1);
     zmq::socket_t repSocket3 (ctx->getContext (), ZMQ_REP);
-    repSocket3.bind ("tcp://127.0.0.1:23407");
+    repSocket3.bind (defRoute2);
 
     reqset.addRoutes (1, defServer);
-    reqset.addRoutes (2, "tcp://127.0.0.1:23406");
-    reqset.addRoutes (3, "tcp://127.0.0.1:23407");
+    reqset.addRoutes (2, defRoute1);
+    reqset.addRoutes (3, defRoute2);
 
     helics::ActionMessage M (helics::CMD_IGNORE);
     M.index = 1;
@@ -126,25 +130,23 @@ BOOST_AUTO_TEST_CASE (zmqRequestSet_test1)
 /** test the request set class with various scenarios*/
 BOOST_AUTO_TEST_CASE (zmqRequestSet_test2)
 {
-    std::string host = "tcp://127.0.0.1";
-
-    helics::ZmqRequestSets reqset;
+    helics::zeromq::ZmqRequestSets reqset;
 
     auto ctx = zmqContextManager::getContextPointer ();
     zmq::socket_t repSocket1 (ctx->getContext (), ZMQ_REP);
     repSocket1.bind (defServer);
     zmq::socket_t repSocket2 (ctx->getContext (), ZMQ_REP);
-    repSocket2.bind ("tcp://127.0.0.1:23406");
+    repSocket2.bind (defRoute1);
     zmq::socket_t repSocket3 (ctx->getContext (), ZMQ_REP);
-    repSocket3.bind ("tcp://127.0.0.1:23407");
+    repSocket3.bind (defRoute2);
 
     repSocket1.setsockopt (ZMQ_LINGER, 100);
     repSocket2.setsockopt (ZMQ_LINGER, 100);
     repSocket3.setsockopt (ZMQ_LINGER, 100);
 
     reqset.addRoutes (1, defServer);
-    reqset.addRoutes (2, "tcp://127.0.0.1:23406");
-    reqset.addRoutes (3, "tcp://127.0.0.1:23407");
+    reqset.addRoutes (2, defRoute1);
+    reqset.addRoutes (3, defRoute2);
 
     helics::ActionMessage M (helics::CMD_IGNORE);
     M.index = 1;
@@ -210,8 +212,7 @@ BOOST_AUTO_TEST_CASE (zmqRequestSet_test2)
 BOOST_AUTO_TEST_CASE (zmqComms_broker_test_transmit)
 {
     std::atomic<int> counter{0};
-    std::string host = "tcp://127.0.0.1";
-    helics::ZmqComms comm (host, host);
+    helics::zeromq::ZmqComms comm (host, host);
 
     auto ctx = zmqContextManager::getContextPointer ();
     zmq::socket_t repSocket (ctx->getContext (), ZMQ_REP);
@@ -229,7 +230,7 @@ BOOST_AUTO_TEST_CASE (zmqComms_broker_test_transmit)
     zmq::socket_t pullSocket (ctx->getContext (), ZMQ_PULL);
     try
     {
-        pullSocket.bind ("tcp://127.0.0.1:23406");
+        pullSocket.bind (defRoute1);
     }
     catch (const zmq::error_t &ze)
     {
@@ -264,8 +265,7 @@ BOOST_AUTO_TEST_CASE (zmqComms_rx_test)
 {
     std::atomic<int> counter{0};
     helics::ActionMessage act;
-    std::string host = "tcp://127.0.0.1";
-    helics::ZmqComms comm (host, host);
+    helics::zeromq::ZmqComms comm (host, host);
 
     auto ctx = zmqContextManager::getContextPointer ();
     zmq::socket_t repSocket (ctx->getContext (), ZMQ_REP);
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE (zmqComms_rx_test)
     zmq::socket_t pullSocket (ctx->getContext (), ZMQ_PULL);
     try
     {
-        pullSocket.bind ("tcp://127.0.0.1:23406");
+        pullSocket.bind (defRoute1);
     }
     catch (const zmq::error_t &ze)
     {
@@ -335,9 +335,8 @@ BOOST_AUTO_TEST_CASE (zmqComm_transmit_through)
     helics::ActionMessage act;
     helics::ActionMessage act2;
 
-    std::string host = "tcp://127.0.0.1";
-    helics::ZmqComms comm (host, host);
-    helics::ZmqComms comm2 (host, "");
+    helics::zeromq::ZmqComms comm (host, host);
+    helics::zeromq::ZmqComms comm2 (host, "");
 
     comm.setBrokerPort (23405);
     comm.setName ("tests");
@@ -382,11 +381,9 @@ BOOST_AUTO_TEST_CASE (zmqComm_transmit_add_route)
     std::atomic<int> counter{0};
     std::atomic<int> counter2{0};
     std::atomic<int> counter3{0};
-
-    std::string host = "tcp://127.0.0.1";
-    helics::ZmqComms comm (host, host);
-    helics::ZmqComms comm2 (host, "");
-    helics::ZmqComms comm3 (host, host);
+    helics::zeromq::ZmqComms comm (host, host);
+    helics::zeromq::ZmqComms comm2 (host, "");
+    helics::zeromq::ZmqComms comm3 (host, host);
 
     comm.setBrokerPort (23405);
     comm.setName ("tests");
@@ -487,7 +484,7 @@ BOOST_AUTO_TEST_CASE (zmqCore_initialization_test)
     zmq::socket_t pullSocket (ctx->getContext (), ZMQ_PULL);
     try
     {
-        pullSocket.bind ("tcp://127.0.0.1:23406");
+        pullSocket.bind (defRoute1);
     }
     catch (const zmq::error_t &ze)
     {

--- a/tests/helics/core/testFixtures.cpp
+++ b/tests/helics/core/testFixtures.cpp
@@ -5,8 +5,8 @@ All rights reserved.
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
+
 #include "testFixtures.h"
 #include <boost/test/unit_test.hpp>
 
@@ -18,10 +18,9 @@ Lawrence Livermore National Laboratory, operated by Lawrence Livermore National 
 #include "helics/core/PublicationInfo.hpp"
 #include "helics/core/SubscriptionInfo.hpp"
 
-federateStateTestFixture::federateStateTestFixture ()
+federateStateTestFixture::federateStateTestFixture ():fs(std::make_unique<helics::FederateState>("fed_name",helics::CoreFederateInfo()))
 {
-    helics::CoreFederateInfo info;
-    fs = std::unique_ptr<helics::FederateState> (new helics::FederateState ("fed_name", info));
+
 }
 
 federateStateTestFixture::~federateStateTestFixture () = default;

--- a/tests/helics/core/testFixtures.h
+++ b/tests/helics/core/testFixtures.h
@@ -5,11 +5,7 @@ All rights reserved.
 This software was co-developed by Pacific Northwest National Laboratory, operated by the Battelle Memorial
 Institute; the National Renewable Energy Laboratory, operated by the Alliance for Sustainable Energy, LLC; and the
 Lawrence Livermore National Laboratory, operated by Lawrence Livermore National Security, LLC.
-
 */
-#ifndef TEST_FIXTURES_HEADER_
-#define TEST_FIXTURES_HEADER_
-
 #include <memory>
 namespace helics
 {
@@ -41,5 +37,3 @@ struct commonCoreTestFixture
 
     std::unique_ptr<helics::CommonCore> core;
 };
-
-#endif


### PR DESCRIPTION
* fix example error

* fix example warning

* add several sub namespaces and minor cppcheck issue fixes

* fix some linux issues and a few more codacy issues.

* fix possible nullptr dereference when serializing values for publications

* fix issue for Broker, from fixes to shared_library termination

* add doc that somehow got removed

* Add missing mpi namespace