### PR TITLE
Test zmq dependency version

### DIFF
--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -18,6 +18,7 @@ cmake_install_path=${CI_DEPENDENCY_DIR}/cmake
 swig_version=3.0.10
 swig_install_path=${CI_DEPENDENCY_DIR}/swig
 
+zmq_version=4.2.3
 zmq_install_path=${CI_DEPENDENCY_DIR}/zmq
 
 # Convert commit message to lower case
@@ -73,7 +74,7 @@ echo "*** built swig successfully {$PATH}"
 # Install ZeroMQ
 if [[ ! -d "${zmq_install_path}" ]]; then
     echo "*** build libzmq"
-    ./scripts/install-dependency.sh zmq ${zmq_install_path}
+    ./scripts/install-dependency.sh zmq ${zmq_version} ${zmq_install_path}
     echo "*** built zmq successfully"
 fi
 

--- a/scripts/install-dependency.sh
+++ b/scripts/install-dependency.sh
@@ -32,8 +32,13 @@ install_swig () {
 
 install_zmq () {
     # Clone the zeromq repo and build it
-    local install_path=$1
-    git clone git://github.com/zeromq/libzmq.git;
+    local zmq_version=$2
+    local install_path=$3
+    if [[ "${zmq_version}" == "HEAD" ]]; then
+        git clone git://github.com/zeromq/libzmq.git;
+    else 
+        git clone --branch v${zmq_version} git://github.com/zeromq/libzmq.git;
+    fi
     (
         cd libzmq;
         ./autogen.sh;
@@ -96,12 +101,15 @@ case "$1" in
         install_swig ${install_version} ${install_path}
         ;;
     zmq)
-        install_path=$2
-        install_zmq ${install_path}
+        if [[ -z $install_path ]]; then
+            install_version="HEAD"
+            install_path=$2
+        fi
+        install_zmq ${install_version} ${install_path}
         ;;
     *)
         echo "Usage:"
         echo "$0 (boost|cmake|swig) version install_path"
-        echo "$0 zmq install_path"
+        echo "$0 zmq [version=HEAD] install_path"
 esac
 

--- a/scripts/install-dependency.sh
+++ b/scripts/install-dependency.sh
@@ -32,8 +32,8 @@ install_swig () {
 
 install_zmq () {
     # Clone the zeromq repo and build it
-    local zmq_version=$2
-    local install_path=$3
+    local zmq_version=$1
+    local install_path=$2
     if [[ "${zmq_version}" == "HEAD" ]]; then
         git clone git://github.com/zeromq/libzmq.git;
     else 


### PR DESCRIPTION
Installs tagged v4.2.3 zmq release instead of latest commit. Avoid potential breakage of zeromq version that is in development.