### PR TITLE
Create HELICS installer and artifact on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,9 @@ build:
   verbosity: minimal
 
 after_build:
+  - cd build
+  - cpack
+  - cd ..
 
 test_script:
   - cd build
@@ -45,6 +48,7 @@ test_script:
   - ctest -C Release --verbose --timeout 90 -I 0,0,0,2
   - ctest -C Release --verbose --timeout 240 -I 0,0,0,4
   #- ctest -C Release --verbose --timeout 90 -I 0,0,0,7
+  - cd ..
 
 artifacts:
-
+  - path: build/Helics-1.0.0-beta.2-win64.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ build:
 
 after_build:
   - cd build
-  - cpack -R ${APPVEYOR_BUILD_VERSION}
+  - cpack -B $PWD/installer-output
   - cd ..
 
 test_script:
@@ -51,4 +51,4 @@ test_script:
   - cd ..
 
 artifacts:
-  - path: build/Helics-${APPVEYOR_BUILD_VERSION}-win64.exe
+  - path: build/installer-output/Helics-*.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 shallow_clone: true
 
-version: 1.0.0.beta.1.{build}
+version: 1.0.0-beta.2.{build}
 
 image: Visual Studio 2015
 
@@ -30,7 +30,7 @@ build:
 
 after_build:
   - cd build
-  - cpack
+  - cpack -R ${APPVEYOR_BUILD_VERSION}
   - cd ..
 
 test_script:
@@ -51,4 +51,4 @@ test_script:
   - cd ..
 
 artifacts:
-  - path: build/Helics-1.0.0-beta.2-win64.exe
+  - path: build/Helics-${APPVEYOR_BUILD_VERSION}-win64.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ build:
 
 after_build:
   - cd build
-  - cpack -B $PWD/installer-output
+  - cpack -B %cd%/installer-output
   - cd ..
 
 test_script:


### PR DESCRIPTION
Install artifact is available at: https://ci.appveyor.com/project/nightlark/helics-src/build/artifacts
Appveyor can upload artifacts to a variety of places with either a deploy section in the config file, or by running curl/ftp to upload files to wherever we want them.