### PR TITLE
This adds several test identical to previous filter tests

### DIFF
--- a/tests/helics/application_api/FilterTests.cpp
+++ b/tests/helics/application_api/FilterTests.cpp
@@ -112,7 +112,65 @@ BOOST_DATA_TEST_CASE (message_filter_function, bdata::make (core_types), core_ty
     BOOST_CHECK (fFed->getCurrentState () == helics::Federate::op_states::finalize);
 }
 
+/** test a filter operator
+The filter operator delays the message by 2.5 seconds meaning it should arrive by 3 sec into the simulation
+*/
 
+BOOST_TEST_DECORATOR(*utf::timeout(12))
+BOOST_DATA_TEST_CASE(message_filter_object, bdata::make(core_types), core_type)
+{
+    auto broker = AddBroker(core_type, 2);
+    AddFederates<helics::MessageFederate>(core_type, 1, broker, 1.0, "filter");
+    AddFederates<helics::MessageFederate>(core_type, 1, broker, 1.0, "message");
+
+    auto fFed = GetFederateAs<helics::MessageFederate>(0);
+    auto mFed = GetFederateAs<helics::MessageFederate>(1);
+
+    auto p1 = mFed->registerGlobalEndpoint("port1");
+    auto p2 = mFed->registerGlobalEndpoint("port2");
+
+    auto Filt = helics::make_source_filter(helics::defined_filter_types::delay, fFed.get(), "port1", "filter1");
+
+    Filt->set("delay", 2.5);
+
+    fFed->enterExecutionStateAsync();
+    mFed->enterExecutionState();
+    fFed->enterExecutionStateComplete();
+
+    BOOST_CHECK(fFed->getCurrentState() == helics::Federate::op_states::execution);
+    helics::data_block data(500, 'a');
+    mFed->sendMessage(p1, "port2", data);
+
+    mFed->requestTimeAsync(1.0);
+    fFed->requestTime(1.0);
+    mFed->requestTimeComplete();
+
+    auto res = mFed->hasMessage();
+    BOOST_CHECK(!res);
+
+    mFed->requestTimeAsync(2.0);
+    fFed->requestTime(2.0);
+    mFed->requestTimeComplete();
+    BOOST_REQUIRE(!mFed->hasMessage(p2));
+
+    fFed->requestTimeAsync(3.0);
+    /*auto retTime = */ mFed->requestTime(3.0);
+
+    BOOST_REQUIRE(mFed->hasMessage(p2));
+
+    auto m2 = mFed->getMessage(p2);
+    BOOST_CHECK_EQUAL(m2->source, "port1");
+    BOOST_CHECK_EQUAL(m2->original_source, "port1");
+    BOOST_CHECK_EQUAL(m2->dest, "port2");
+    BOOST_CHECK_EQUAL(m2->data.size(), data.size());
+    BOOST_CHECK_EQUAL(m2->time, 2.5);
+
+    mFed->requestTime(3.0);
+    fFed->requestTimeComplete();
+    mFed->finalize();
+    fFed->finalize();
+    BOOST_CHECK(fFed->getCurrentState() == helics::Federate::op_states::finalize);
+}
 /** test a remove dest filter operator
 The filter operator delays the message by 2.5 seconds meaning it should arrive by 3 sec into the simulation
 */
@@ -175,6 +233,67 @@ BOOST_DATA_TEST_CASE(message_dest_filter_function, bdata::make(core_types), core
     BOOST_CHECK(fFed->getCurrentState() == helics::Federate::op_states::finalize);
 }
 
+
+/** test a remove dest filter operator
+The filter operator delays the message by 2.5 seconds meaning it should arrive by 3 sec into the simulation
+*/
+
+BOOST_TEST_DECORATOR(*utf::timeout(12))
+BOOST_DATA_TEST_CASE(message_dest_filter_object, bdata::make(core_types), core_type)
+{
+    auto broker = AddBroker(core_type, 2);
+    AddFederates<helics::MessageFederate>(core_type, 1, broker, 1.0, "filter");
+    AddFederates<helics::MessageFederate>(core_type, 1, broker, 1.0, "message");
+
+    auto fFed = GetFederateAs<helics::MessageFederate>(0);
+    auto mFed = GetFederateAs<helics::MessageFederate>(1);
+
+    auto p1 = mFed->registerGlobalEndpoint("port1");
+    auto p2 = mFed->registerGlobalEndpoint("port2");
+
+    auto f1 = helics::make_destination_filter(helics::defined_filter_types::delay, fFed->getCorePointer().get(), "port2", "filter1");
+    f1->set("delay", 2.5);
+
+    fFed->enterExecutionStateAsync();
+    mFed->enterExecutionState();
+    fFed->enterExecutionStateComplete();
+
+    BOOST_CHECK(fFed->getCurrentState() == helics::Federate::op_states::execution);
+    helics::data_block data(500, 'a');
+    mFed->sendMessage(p1, "port2", data);
+
+    mFed->requestTimeAsync(1.0);
+    fFed->requestTime(1.0);
+    mFed->requestTimeComplete();
+
+    auto res = mFed->hasMessage();
+    BOOST_CHECK(!res);
+
+    mFed->requestTimeAsync(2.0);
+    fFed->requestTime(2.0);
+    mFed->requestTimeComplete();
+    BOOST_REQUIRE(!mFed->hasMessage(p2));
+
+    fFed->requestTimeAsync(3.0);
+    /*auto retTime = */ mFed->requestTime(3.0);
+
+    BOOST_REQUIRE(mFed->hasMessage(p2));
+
+    auto m2 = mFed->getMessage(p2);
+    BOOST_CHECK_EQUAL(m2->source, "port1");
+    BOOST_CHECK_EQUAL(m2->original_source, "port1");
+    BOOST_CHECK_EQUAL(m2->dest, "port2");
+    BOOST_CHECK_EQUAL(m2->data.size(), data.size());
+    BOOST_CHECK_EQUAL(m2->time, 2.5);
+
+    mFed->requestTime(3.0);
+    fFed->requestTimeComplete();
+    mFed->finalize();
+    fFed->finalize();
+    BOOST_CHECK(fFed->getCurrentState() == helics::Federate::op_states::finalize);
+}
+
+
 /** test a filter operator
 The filter operator delays the message by 2.5 seconds meaning it should arrive by 3 sec into the simulation
 */
@@ -205,6 +324,81 @@ BOOST_DATA_TEST_CASE(message_filter_function_two_stage, bdata::make(core_types),
 
     fFed2->setFilterOperator(f2, timeOperator);
 
+    fFed->enterExecutionStateAsync();
+    fFed2->enterExecutionStateAsync();
+    mFed->enterExecutionState();
+    fFed->enterExecutionStateComplete();
+    fFed2->enterExecutionStateComplete();
+
+    BOOST_CHECK(fFed->getCurrentState() == helics::Federate::op_states::execution);
+    helics::data_block data(500, 'a');
+    mFed->sendMessage(p1, "port2", data);
+
+    mFed->requestTimeAsync(1.0);
+    fFed->requestTimeAsync(1.0);
+    fFed2->requestTime(1.0);
+    mFed->requestTimeComplete();
+    fFed->requestTimeComplete();
+    auto res = mFed->hasMessage();
+    BOOST_CHECK(!res);
+
+    mFed->requestTimeAsync(2.0);
+    fFed2->requestTimeAsync(2.0);
+    fFed->requestTime(2.0);
+    mFed->requestTimeComplete();
+    fFed2->requestTimeComplete();
+    BOOST_REQUIRE(!mFed->hasMessage(p2));
+
+    fFed->requestTimeAsync(3.0);
+    fFed2->requestTimeAsync(3.0);
+    /*auto retTime = */ mFed->requestTime(3.0);
+    if (!mFed->hasMessage(p2))
+    {
+        printf("missing message\n");
+    }
+    BOOST_REQUIRE(mFed->hasMessage(p2));
+
+    auto m2 = mFed->getMessage(p2);
+    BOOST_CHECK_EQUAL(m2->source, "port1");
+    BOOST_CHECK_EQUAL(m2->original_source, "port1");
+    BOOST_CHECK_EQUAL(m2->dest, "port2");
+    BOOST_CHECK_EQUAL(m2->data.size(), data.size());
+    BOOST_CHECK_EQUAL(m2->time, 2.5);
+
+    fFed->requestTimeComplete();
+    fFed2->requestTimeComplete();
+    mFed->finalize();
+    fFed->finalize();
+    fFed2->finalize();
+    BOOST_CHECK(fFed->getCurrentState() == helics::Federate::op_states::finalize);
+}
+
+
+/** test a filter operator
+The filter operator delays the message by 2.5 seconds meaning it should arrive by 3 sec into the simulation
+*/
+
+BOOST_TEST_DECORATOR(*utf::timeout(12))
+BOOST_DATA_TEST_CASE(message_filter_function_two_stage_object, bdata::make(core_types), core_type)
+{
+    auto broker = AddBroker(core_type, 3);
+    AddFederates<helics::MessageFederate>(core_type, 1, broker, 1.0, "filter");
+    AddFederates<helics::MessageFederate>(core_type, 1, broker, 1.0, "filter2");
+    AddFederates<helics::MessageFederate>(core_type, 1, broker, 1.0, "message");
+
+    auto fFed = GetFederateAs<helics::MessageFederate>(0);
+    auto fFed2 = GetFederateAs<helics::MessageFederate>(1);
+    auto mFed = GetFederateAs<helics::MessageFederate>(2);
+
+    auto p1 = mFed->registerGlobalEndpoint("port1");
+    auto p2 = mFed->registerGlobalEndpoint("port2");
+
+    auto f1 = helics::make_source_filter(helics::defined_filter_types::delay, fFed.get(), "port1", "filter1");
+    f1->set("delay", 1.25);
+  
+    auto f2 = helics::make_source_filter(helics::defined_filter_types::delay, fFed.get(), "port1", "filter2");
+    f2->set("delay", 1.25);
+   
     fFed->enterExecutionStateAsync();
     fFed2->enterExecutionStateAsync();
     mFed->enterExecutionState();


### PR DESCRIPTION
Basically adds a number of tests specific to the filter object creation in C++.  There were no issues that came up from the tests so this is just to add the tests into the main branch.  

A future effort will be to make a much more extensive test suite that fully exercises the built in filters.  This PR just verifies they work nominally in a defined circumstance.  