### PR TITLE
Additional timing tests

### DIFF
--- a/src/helics/core/FederateState.cpp
+++ b/src/helics/core/FederateState.cpp
@@ -1036,40 +1036,7 @@ iteration_state FederateState::processActionMessage (ActionMessage &cmd)
         }
 
         break;
-        /*
-    case CMD_REG_DST_FILTER:
-    case CMD_NOTIFY_DST_FILTER:
-    {
-        if (!checkActionFlag (cmd, clone_flag))
-        {
-            auto endI = getEndpoint (cmd.dest_handle);
-            if (endI != nullptr)
-            {
-                addDependency (cmd.source_id);
-            }
-        }
-        else
-        {
-            auto endI = getEndpoint(cmd.dest_handle);
-            if (endI != nullptr)
-            {
-                addDependency(cmd.source_id);
-            }
-        }
-        break;
-    }
-    case CMD_REG_SRC_FILTER:
-    case CMD_NOTIFY_SRC_FILTER:
-    {
-        auto endI = getEndpoint (cmd.dest_handle);
-        if (endI != nullptr)
-        {
-            endI->hasFilter = true;
-            addDependent (cmd.source_id);
-        }
-    }
-    break;
-    */
+   
     case CMD_FED_ACK:
         if (state != HELICS_CREATED)
         {
@@ -1086,6 +1053,9 @@ iteration_state FederateState::processActionMessage (ActionMessage &cmd)
             timeCoord->source_id = global_id;
             return iteration_state::next_step;
         }
+        break;
+    case CMD_FED_CONFIGURE:
+        processConfigUpdate(cmd);
         break;
     }
     return iteration_state::continue_processing;

--- a/tests/helics/application_api/TimingTests.cpp
+++ b/tests/helics/application_api/TimingTests.cpp
@@ -157,19 +157,38 @@ BOOST_AUTO_TEST_CASE(timing_with_minDelta_change)
     
     auto res = vFed1->requestTime(1.0);
     // check that the request is only granted at the appropriate period
-    BOOST_CHECK_EQUAL(res, 1.0);
-    ept1.send("e2", "test1");
-    vFed1->requestTimeAsync(1.9);
-    res = vFed2->requestTimeComplete();
-    BOOST_CHECK_EQUAL(
-        res, 1.1);  // the message should show up at the next available time point after the impact window
-    vFed2->requestTimeAsync(2.0);
-    res = vFed1->requestTimeComplete();
-    BOOST_CHECK_EQUAL(res, 1.9);
-    res = vFed2->requestTimeComplete();
+    
+    BOOST_CHECK_EQUAL(res, 1.0);  
+
+    //purposely requesting 1.0 to test min delta
+    res = vFed1->requestTime(1.0);
     BOOST_CHECK_EQUAL(res, 2.0);
+
+    vFed1->setTimeDelta(0.1);
+    res = vFed1->requestTime(res);
+    BOOST_CHECK_EQUAL(res, 2.1);
     vFed1->finalize();
-    vFed2
-        ->finalize();  // this will also test finalizing while a time request is ongoing otherwise it will time out.
+}
+
+BOOST_AUTO_TEST_CASE(timing_with_period_change)
+{
+    SetupTest<helics::ValueFederate>("test", 1);
+    auto vFed1 = GetFederateAs<helics::ValueFederate>(0);
+    vFed1->setPeriod(1.0);
+    vFed1->enterExecutionState();
+
+    auto res = vFed1->requestTime(1.0);
+    // check that the request is only granted at the appropriate period
+
+    BOOST_CHECK_EQUAL(res, 1.0);
+
+    //purposely requesting 1.0 to test min delta
+    res = vFed1->requestTime(1.0);
+    BOOST_CHECK_EQUAL(res, 2.0);
+
+    vFed1->setPeriod(0.1);
+    res = vFed1->requestTime(res);
+    BOOST_CHECK_EQUAL(res, 2.1);
+    vFed1->finalize();
 }
 BOOST_AUTO_TEST_SUITE_END ()


### PR DESCRIPTION
Fix for #284,  the configure message was not being processed when stuck in the queue, also deleted some commented out code.