### PR TITLE
Broker network specs updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ jobs:
           packages:
             - clang-3.6
       env:
-        - MATRIX_EVAL="COMPILER=clang && CC='ccache clang-3.6' && CXX='ccache clang++-3.6'"
+        - MATRIX_EVAL="COMPILER=clang && CC='clang-3.6' && CXX='clang++-3.6'"
         - CCACHE_CPP2=yes
         - SHARED_LIB_EXT=so
         - USE_SWIG=true
@@ -141,7 +141,7 @@ jobs:
             - libstdc++-6-dev
             - clang-5.0
       env:
-        - MATRIX_EVAL="COMPILER=clang && CC='ccache clang-5.0' && CXX='ccache clang++-5.0'"
+        - MATRIX_EVAL="COMPILER=clang && CC='clang-5.0' && CXX='clang++-5.0'"
         - CCACHE_CPP2=yes
         - SHARED_LIB_EXT=so
         - USE_SWIG=true
@@ -168,7 +168,7 @@ script:
     # - echo "$HELICS_OPTION_FLAGS"
     # - echo "$HELICS_DEPENDENCY_FLAGS"
   - if [[ "$USE_MPI" ]]; then CC=${CI_DEPENDENCY_DIR}/mpi/bin/mpicc ; CXX=${CI_DEPENDENCY_DIR}/mpi/bin/mpic++ ; fi
-  - cmake .. ${HELICS_DEPENDENCY_FLAGS} ${HELICS_OPTION_FLAGS}
+  - cmake .. ${HELICS_DEPENDENCY_FLAGS} ${HELICS_OPTION_FLAGS} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
   - make -j2
   # For controlling which tests get run:
   # ctest -I <start>,<end>,<stride>,<list of test numbers>

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -4,6 +4,8 @@
 if [[ "$TRAVIS" == "true" ]]; then
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         HOMEBREW_NO_AUTO_UPDATE=1 brew install pcre
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache
+        export PATH="/usr/local/opt/ccache/libexec:$PATH"
     fi
 
     export CI_DEPENDENCY_DIR=${TRAVIS_BUILD_DIR}/dependencies

--- a/src/helics/application_api/ValueFederate.cpp
+++ b/src/helics/application_api/ValueFederate.cpp
@@ -87,10 +87,6 @@ subscription_id_t ValueFederate::registerRequiredSubscription (const std::string
                                                                const std::string &type,
                                                                const std::string &units)
 {
-    if (state != op_states::startup)
-    {
-        throw (InvalidFunctionCall ("cannot call register subscription after entering initialization mode"));
-    }
     return vfManager->registerRequiredSubscription (key, type, units);
 }
 
@@ -98,10 +94,6 @@ subscription_id_t ValueFederate::registerOptionalSubscription (const std::string
                                                                const std::string &type,
                                                                const std::string &units)
 {
-    if (state != op_states::startup)
-    {
-        throw (InvalidFunctionCall ("cannot call register subscription after entering initialization mode"));
-    }
     return vfManager->registerOptionalSubscription (key, type, units);
 }
 

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -437,7 +437,7 @@ federate_id_t CommonCore::registerFederate (const std::string &name, const CoreF
     {
         return local_id;
     }
-    throw (RegistrationFailure ());
+    throw (RegistrationFailure (fed->lastErrorString()));
 }
 
 const std::string &CommonCore::getFederateName (federate_id_t federateID) const

--- a/src/helics/core/CommsBroker.cpp
+++ b/src/helics/core/CommsBroker.cpp
@@ -12,7 +12,9 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #include "CoreBroker.hpp"
 #include "ipc/IpcComms.h"
 #include "udp/UdpComms.h"
+#ifdef HELICS_HAVE_ZEROMQ
 #include "zmq/ZmqComms.h"
+#endif
 
 #ifndef DISABLE_TCP_CORE
 #include "tcp/TcpComms.h"
@@ -26,8 +28,10 @@ namespace helics
 {
 template class CommsBroker<ipc::IpcComms, CoreBroker>;
 template class CommsBroker<ipc::IpcComms, CommonCore>;
+#ifdef HELICS_HAVE_ZEROMQ
 template class CommsBroker<zeromq::ZmqComms, CoreBroker>;
 template class CommsBroker<zeromq::ZmqComms, CommonCore>;
+#endif
 template class CommsBroker<udp::UdpComms, CoreBroker>;
 template class CommsBroker<udp::UdpComms, CommonCore>;
 

--- a/src/helics/core/CommsInterface.cpp
+++ b/src/helics/core/CommsInterface.cpp
@@ -9,15 +9,16 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 namespace helics
 {
 CommsInterface::CommsInterface (const std::string &localTarget, const std::string &brokerTarget)
-    : localTarget_ (localTarget), brokerTarget_ (brokerTarget)
+    : localTarget_ (localTarget), brokerTarget_ (brokerTarget), interfaceNetwork(interface_networks::local)
 {
 }
 
 CommsInterface::CommsInterface (const NetworkBrokerData &netInfo)
     : localTarget_ (netInfo.localInterface), brokerTarget_ (netInfo.brokerAddress),
-      brokerName_ (netInfo.brokerName)
+      brokerName_ (netInfo.brokerName), interfaceNetwork(interfaceNetwork)
 {
 }
+
 /** destructor*/
 CommsInterface::~CommsInterface ()
 {

--- a/src/helics/core/CommsInterface.cpp
+++ b/src/helics/core/CommsInterface.cpp
@@ -8,14 +8,14 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 
 namespace helics
 {
-CommsInterface::CommsInterface (const std::string &localTarget, const std::string &brokerTarget)
-    : localTarget_ (localTarget), brokerTarget_ (brokerTarget), interfaceNetwork(interface_networks::local)
+CommsInterface::CommsInterface (const std::string &localTarget, const std::string &brokerTarget, interface_networks targetNetwork)
+    : localTarget_ (localTarget), brokerTarget_ (brokerTarget), interfaceNetwork(targetNetwork)
 {
 }
 
 CommsInterface::CommsInterface (const NetworkBrokerData &netInfo)
     : localTarget_ (netInfo.localInterface), brokerTarget_ (netInfo.brokerAddress),
-      brokerName_ (netInfo.brokerName), interfaceNetwork(interfaceNetwork)
+      brokerName_ (netInfo.brokerName), interfaceNetwork(netInfo.interfaceNetwork)
 {
 }
 

--- a/src/helics/core/CommsInterface.hpp
+++ b/src/helics/core/CommsInterface.hpp
@@ -13,6 +13,7 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 namespace helics
 {
 class NetworkBrokerData;
+enum class interface_networks :char;
 
 /** implementation of a generic communications interface
  */
@@ -85,12 +86,14 @@ class CommsInterface
     int connectionTimeout = 4000;  // timeout for the initial connection to a broker
     int maxMessageSize_ = 16 * 1024;  //!< the maximum message size for the queues (if needed)
     int maxMessageCount_ = 512;  //!< the maximum number of message to buffer (if needed)
+    
     std::function<void(ActionMessage &&)> ActionCallback;  //!< the callback for what to do with a received message
     BlockingPriorityQueue<std::pair<int, ActionMessage>> txQueue;  //!< set of messages waiting to be transmitted
     // closing the files or connection can take some time so there is a need for inter-thread communication to not
     // spit out warning messages if it is in the process of disconnecting
     std::atomic<bool> disconnecting{
       false};  //!< flag indicating that the comm system is in the process of disconnecting
+    interface_networks interfaceNetwork;
   private:
     std::thread queue_transmitter;  //!< single thread for sending data
     std::thread queue_watcher;  //!< thread monitoring the receive queue

--- a/src/helics/core/CommsInterface.hpp
+++ b/src/helics/core/CommsInterface.hpp
@@ -7,12 +7,12 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 
 #include "../common/BlockingPriorityQueue.hpp"
 #include "../common/TripWire.hpp"
+#include "NetworkBrokerData.hpp"
 #include "ActionMessage.hpp"
 #include <functional>
 #include <thread>
 namespace helics
 {
-class NetworkBrokerData;
 enum class interface_networks :char;
 
 /** implementation of a generic communications interface
@@ -26,7 +26,7 @@ class CommsInterface
     @param localTarget the interface or specification that should be set to receive incoming connections
     @param brokerTarget the target of the broker Interface to link to
     */
-    CommsInterface (const std::string &localTarget, const std::string &brokerTarget);
+    CommsInterface (const std::string &localTarget, const std::string &brokerTarget, interface_networks targetNetwork = interface_networks::local);
     /** construct from a NetworkBrokerData structure*/
     explicit CommsInterface (const NetworkBrokerData &netInfo);
     /** destructor*/

--- a/src/helics/core/FederateState.cpp
+++ b/src/helics/core/FederateState.cpp
@@ -978,6 +978,7 @@ iteration_state FederateState::processActionMessage (ActionMessage &cmd)
     break;
     case CMD_ERROR:
         setState (HELICS_ERROR);
+        errorString = commandErrorString(cmd.index);
         return iteration_state::error;
     case CMD_REG_PUB:
     {
@@ -1035,6 +1036,7 @@ iteration_state FederateState::processActionMessage (ActionMessage &cmd)
             if (checkActionFlag (cmd, error_flag))
             {
                 setState (HELICS_ERROR);
+                errorString = commandErrorString(cmd.index);
                 return iteration_state::error;
             }
             global_id = cmd.dest_id;

--- a/src/helics/core/FederateState.hpp
+++ b/src/helics/core/FederateState.hpp
@@ -53,6 +53,7 @@ class FederateState
   private:
     shared_guarded<DualMappedPointerVector<SubscriptionInfo, std::string, Core::handle_id_t>>
       subscriptions;  //!< storage for all the subscriptions
+    
     std::atomic<federate_state_t> state{HELICS_NONE};  //!< the current state of the federate
     bool only_update_on_change{false};  //!< flag indicating that values should only be updated on change
     bool only_transmit_on_change{
@@ -66,6 +67,7 @@ class FederateState
     std::atomic<bool> init_transmitted{false};  //!< the initialization request has been transmitted
   private:
     CommonCore *parent_ = nullptr;  //!< pointer to the higher level;
+    std::string errorString; //!< storage for an error string populated on an error
   public:
     std::atomic<bool> init_requested{false};  //!< this federate has requested entry to initialization
 
@@ -74,7 +76,7 @@ class FederateState
     bool timeGranted_mode =
       false;  //!< indicator if the federate is in a granted state or a requested state waiting to grant
     // 1 byte free
-    int logLevel = 1;
+    int logLevel = 1;  //!< the level of logging used in the federate
 
     //   std::vector<ActionMessage> messLog;
   private:
@@ -225,7 +227,8 @@ class FederateState
     /** get a reference to the global ids of dependent federates
      */
     const std::vector<Core::federate_id_t> &getDependents () const;
-
+    /** get the last error string */
+    const std::string &lastErrorString() const { return errorString; }
     void setCoreObject (CommonCore *parent);
     // the next 5 functions are the processing functions that actually process the queue
     /** process until the federate has verified its membership and assigned a global id number*/

--- a/src/helics/core/NetworkBrokerData.hpp
+++ b/src/helics/core/NetworkBrokerData.hpp
@@ -3,7 +3,6 @@ Copyright © 2017-2018,
 Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC
 All rights reserved. See LICENSE file and DISCLAIMER for more details.
 */
-
 #pragma once
 
 #include <string>

--- a/src/helics/core/NetworkBrokerData.hpp
+++ b/src/helics/core/NetworkBrokerData.hpp
@@ -10,24 +10,36 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 
 namespace helics
 {
+/** define the network access*/
+enum class interface_networks :char
+{
+    local,  //!< just open local ports
+    ipv4,  //!< use external ipv4 ports
+    ipv6,  //!< use external ipv6 ports
+    all, //!< use all external ports
+};
+
 /** helper class designed to contain the common elements between networking brokers and cores
  */
 class NetworkBrokerData
 {
   public:
     /** define keys for particular interfaces*/
-    enum class interface_type
+    enum class interface_type:char
     {
         tcp,  //!< using tcp ports for communication
         udp,  //!< using udp ports for communication
         both,  //!< using both types of ports for communication
     };
+   
+    
     std::string brokerName;  //!< the identifier for the broker
     std::string brokerAddress;  //!< the address or domain name of the broker
     std::string localInterface;  //!< the interface to use for the local receive ports
     int portNumber = -1;  //!< the port number for the local interface
     int brokerPort = -1;  //!< the port number to use for the main broker interface
     int portStart = -1;  //!< the starting port for automatic port definitions
+    interface_networks interfaceNetwork = interface_networks::local;
   public:
     NetworkBrokerData () = default;
     /** constructor from the allowed type*/
@@ -49,6 +61,7 @@ class NetworkBrokerData
     /** do some checking on the brokerAddress*/
     void checkAndUpdateBrokerAddress (const std::string &localAddress);
     interface_type allowedType = interface_type::both;
+    
 };
 
 /** generate a string with a full address based on an interface string and port number
@@ -78,10 +91,29 @@ or the interface doesn't use port numbers
 */
 std::pair<std::string, std::string> extractInterfaceandPortString (const std::string &address);
 
+/** check if a specfied address is v6 or v4
+@return true if the address is a v6 address
+*/
+bool isipv6(const std::string &address);
+
 /** get the external ipv4 address of the current computer
  */
 std::string getLocalExternalAddressV4 ();
 
 /** get the external ipv4 Ethernet address of the current computer that best matches the listed server*/
+std::string getLocalExternalAddress(const std::string &server);
+
+/** get the external ipv4 Ethernet address of the current computer that best matches the listed server*/
 std::string getLocalExternalAddressV4 (const std::string &server);
+
+/** get the external ipv4 address of the current computer
+*/
+std::string getLocalExternalAddressV6();
+
+/** get the external ipv4 Ethernet address of the current computer that best matches the listed server*/
+std::string getLocalExternalAddressV6(const std::string &server);
+
+/** generate an interface that matches a defined server or network specification
+*/
+std::string generateMatchingInterfaceAddress(const std::string &server, interface_networks network=interface_networks::local);
 }  // namespace helics

--- a/src/helics/core/tcp/TcpComms.cpp
+++ b/src/helics/core/tcp/TcpComms.cpp
@@ -22,12 +22,32 @@ namespace tcp
 using boost::asio::ip::tcp;
 TcpComms::TcpComms () noexcept {}
 
-TcpComms::TcpComms (const std::string &brokerTarget, const std::string &localTarget)
-    : CommsInterface (brokerTarget, localTarget)
+TcpComms::TcpComms (const std::string &brokerTarget, const std::string &localTarget, interface_networks targetNetwork)
+    : CommsInterface (brokerTarget, localTarget,targetNetwork)
 {
     if (localTarget_.empty ())
     {
-        localTarget_ = "localhost";
+        if ((brokerTarget_ == "udp://127.0.0.1") || (brokerTarget_ == "udp://localhost") || (brokerTarget_ == "localhost"))
+        {
+            localTarget_ = "localhost";
+        }
+        else if (brokerTarget_.empty())
+        {
+            switch (interfaceNetwork)
+            {
+            case interface_networks::local:
+                localTarget_ = "localhost";
+                break;
+            default:
+                localTarget_ = "*";
+                break;
+            }
+        }
+        else
+        {
+            localTarget_ = generateMatchingInterfaceAddress(brokerTarget_, interfaceNetwork);
+
+        }
     }
 }
 
@@ -36,7 +56,27 @@ TcpComms::TcpComms (const NetworkBrokerData &netInfo)
 {
     if (localTarget_.empty ())
     {
-        localTarget_ = "localhost";
+        if ((brokerTarget_ == "tcp://127.0.0.1") || (brokerTarget_ == "tcp://localhost") || (brokerTarget_ == "localhost"))
+        {
+            localTarget_ = "localhost";
+        }
+        else if (brokerTarget_.empty())
+        {
+            switch (interfaceNetwork)
+            {
+            case interface_networks::local:
+                localTarget_ = "localhost";
+                break;
+            default:
+                localTarget_ = "*";
+                break;
+            }
+        }
+        else
+        {
+            localTarget_ = generateMatchingInterfaceAddress(brokerTarget_, interfaceNetwork);
+
+        }
     }
     if (netInfo.portStart > 0)
     {

--- a/src/helics/core/tcp/TcpComms.h
+++ b/src/helics/core/tcp/TcpComms.h
@@ -55,7 +55,7 @@ class TcpComms final : public CommsInterface
   public:
     /** default constructor*/
     TcpComms () noexcept;
-    TcpComms (const std::string &brokerTarget, const std::string &localTarget);
+    TcpComms (const std::string &brokerTarget, const std::string &localTarget, interface_networks targetNetwork = interface_networks::local);
     TcpComms (const NetworkBrokerData &netInfo);
     /** destructor*/
     ~TcpComms ();

--- a/src/helics/core/udp/UdpComms.cpp
+++ b/src/helics/core/udp/UdpComms.cpp
@@ -27,12 +27,32 @@ UdpComms::UdpComms ()
     futurePort = promisePort.get_future ();
 }
 
-UdpComms::UdpComms (const std::string &brokerTarget, const std::string &localTarget)
-    : CommsInterface (brokerTarget, localTarget)
+UdpComms::UdpComms (const std::string &brokerTarget, const std::string &localTarget, interface_networks targetNetwork)
+    : CommsInterface (brokerTarget, localTarget,targetNetwork)
 {
     if (localTarget_.empty ())
     {
-        localTarget_ = "localhost";
+        if ((brokerTarget_ == "udp://127.0.0.1") || (brokerTarget_ == "udp://localhost")||(brokerTarget_=="localhost"))
+        {
+            localTarget_ = "localhost";
+        }
+        else if (brokerTarget_.empty())
+        {
+            switch (interfaceNetwork)
+            {
+            case interface_networks::local:
+                localTarget_ = "localhost";
+                break;
+            default:
+                localTarget_ = "*";
+                break;
+            }
+        }
+        else
+        {
+            localTarget_ = generateMatchingInterfaceAddress(brokerTarget_, interfaceNetwork);
+
+        }
     }
     promisePort = std::promise<int> ();
     futurePort = promisePort.get_future ();
@@ -43,7 +63,27 @@ UdpComms::UdpComms (const NetworkBrokerData &netInfo)
 {
     if (localTarget_.empty ())
     {
-        localTarget_ = "localhost";
+        if ((brokerTarget_ == "udp://127.0.0.1") || (brokerTarget_ == "udp://localhost") || (brokerTarget_ == "localhost"))
+        {
+            localTarget_ = "localhost";
+        }
+        else if (brokerTarget_.empty())
+        {
+            switch (interfaceNetwork)
+            {
+            case interface_networks::local:
+                localTarget_ = "localhost";
+                break;
+            default:
+                localTarget_ = "*";
+                break;
+            }
+        }
+        else
+        {
+            localTarget_ = generateMatchingInterfaceAddress(brokerTarget_, interfaceNetwork);
+
+        }
     }
     if (netInfo.portStart > 0)
     {

--- a/src/helics/core/udp/UdpComms.h
+++ b/src/helics/core/udp/UdpComms.h
@@ -37,7 +37,7 @@ class UdpComms final : public CommsInterface
   public:
     /** default constructor*/
     UdpComms ();
-    UdpComms (const std::string &brokerTarget, const std::string &localTarget);
+    UdpComms (const std::string &brokerTarget, const std::string &localTarget, interface_networks targetNetwork = interface_networks::local);
     UdpComms (const NetworkBrokerData &netInfo);
     /** destructor*/
     ~UdpComms ();

--- a/src/helics/core/zmq/ZmqComms.cpp
+++ b/src/helics/core/zmq/ZmqComms.cpp
@@ -1,5 +1,4 @@
 /*
-
 Copyright © 2017-2018,
 Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC
 All rights reserved. See LICENSE file and DISCLAIMER for more details.
@@ -25,8 +24,8 @@ namespace helics
 {
 namespace zeromq
 {
-ZmqComms::ZmqComms (const std::string &brokerTarget, const std::string &localTarget)
-    : CommsInterface (brokerTarget, localTarget)
+ZmqComms::ZmqComms (const std::string &brokerTarget, const std::string &localTarget, interface_networks targetNetwork)
+    : CommsInterface (brokerTarget, localTarget,targetNetwork)
 {
     if (localTarget_.empty ())
     {
@@ -40,11 +39,27 @@ ZmqComms::ZmqComms (const std::string &brokerTarget, const std::string &localTar
         }
         else if (brokerTarget_.empty())
         {
-            localTarget_= "tcp://127.0.0.1";
+            switch (interfaceNetwork)
+            {
+            case interface_networks::local:
+                localTarget_ = "tcp://127.0.0.1";
+                break;
+            default:
+                localTarget_ = "tcp://*";
+                break;
+            }
         }
         else
         {
             localTarget_ = generateMatchingInterfaceAddress(brokerTarget_);
+            if (brokerTarget_.compare(0, 3, "tcp"))
+            {
+                localTarget_ = "tcp://" + localTarget_;
+            }
+            else if (brokerTarget_.compare(0, 3, "udp"))
+            {
+                localTarget_ = "udp://" + localTarget_;
+            }
         }
     }
 }
@@ -61,9 +76,30 @@ ZmqComms::ZmqComms (const NetworkBrokerData &netInfo) : CommsInterface (netInfo)
         {
             localTarget_ = "udp://127.0.0.1";
         }
+        else if (brokerTarget_.empty())
+        {
+            switch (interfaceNetwork)
+            {
+            case interface_networks::local:
+                localTarget_ = "tcp://127.0.0.1";
+                break;
+            default:
+                localTarget_ = "tcp://*";
+                break;
+            }
+            
+        }
         else
         {
             localTarget_ = generateMatchingInterfaceAddress(brokerTarget_, interfaceNetwork);
+            if (brokerTarget_.compare(0, 3, "tcp"))
+            {
+                localTarget_ = "tcp://" + localTarget_;
+            }
+            else if (brokerTarget_.compare(0, 3, "udp"))
+            {
+                localTarget_ = "udp://" + localTarget_;
+            }
             
         }
     }

--- a/src/helics/core/zmq/ZmqComms.cpp
+++ b/src/helics/core/zmq/ZmqComms.cpp
@@ -34,10 +34,17 @@ ZmqComms::ZmqComms (const std::string &brokerTarget, const std::string &localTar
         {
             localTarget_ = "tcp://127.0.0.1";
         }
+        else if ((brokerTarget_ == "udp://127.0.0.1") || (brokerTarget_ == "udp://localhost"))
+        {
+            localTarget_ = "udp://127.0.0.1";
+        }
+        else if (brokerTarget_.empty())
+        {
+            localTarget_= "tcp://127.0.0.1";
+        }
         else
         {
-            localTarget_ =
-              "tcp://127.0.0.1";  // TODO this is not correct yet, but I need other functionality to fix it
+            localTarget_ = generateMatchingInterfaceAddress(brokerTarget_);
         }
     }
 }
@@ -50,10 +57,14 @@ ZmqComms::ZmqComms (const NetworkBrokerData &netInfo) : CommsInterface (netInfo)
         {
             localTarget_ = "tcp://127.0.0.1";
         }
+        else if ((brokerTarget_ == "udp://127.0.0.1") || (brokerTarget_ == "udp://localhost"))
+        {
+            localTarget_ = "udp://127.0.0.1";
+        }
         else
         {
-            localTarget_ =
-              "tcp://127.0.0.1";  // TODO this is not correct yet, but I need other functionality to fix it
+            localTarget_ = generateMatchingInterfaceAddress(brokerTarget_, interfaceNetwork);
+            
         }
     }
     if (netInfo.brokerPort > 0)

--- a/src/helics/core/zmq/ZmqComms.h
+++ b/src/helics/core/zmq/ZmqComms.h
@@ -26,7 +26,7 @@ class ZmqComms final:public CommsInterface {
 public:
 	/** default constructor*/
 	ZmqComms() = default;
-	ZmqComms(const std::string &brokerTarget, const std::string &localTarget);
+	ZmqComms(const std::string &brokerTarget, const std::string &localTarget, interface_networks targetNetwork = interface_networks::local);
     ZmqComms(const NetworkBrokerData &netInfo);
 	/** destructor*/
 	~ZmqComms();

--- a/src/helics/shared_api_library/FederateExport.cpp
+++ b/src/helics/shared_api_library/FederateExport.cpp
@@ -92,136 +92,135 @@ std::shared_ptr<helics::MessageFederate> getMessageFedSharedPtr (helics_federate
 /* Creation and destruction of Federates */
 helics_federate helicsCreateValueFederate (const helics_federate_info_t fi)
 {
-    auto *fed = new helics::FedObject;
+    auto FedI = std::make_unique<helics::FedObject>();
     try
     {
         if (fi == nullptr)
         {
-            fed->fedptr = std::make_shared<helics::ValueFederate>(helics::FederateInfo());
+            FedI->fedptr = std::make_shared<helics::ValueFederate>(helics::FederateInfo());
         }
         else
         {
-            fed->fedptr = std::make_shared<helics::ValueFederate>(*reinterpret_cast<helics::FederateInfo *> (fi));
+            FedI->fedptr = std::make_shared<helics::ValueFederate>(*reinterpret_cast<helics::FederateInfo *> (fi));
         }
     }
     catch (const helics::RegistrationFailure &)
     {
-        delete fed;
         return nullptr;
     }
-    fed->index = getMasterHolder()->addFed(fed);
-    fed->type = helics::vtype::valueFed;
-    fed->valid = fedValidationIdentifier;
-    return reinterpret_cast<void *> (fed);
+    FedI->type = helics::vtype::valueFed;
+    FedI->valid = fedValidationIdentifier;
+    auto fed = reinterpret_cast<void *>(FedI.get());
+    getMasterHolder()->addFed(std::move(FedI));
+    return  (fed);
 }
 
 helics_federate helicsCreateValueFederateFromJson (const char *json)
 {
-    auto *fed = new helics::FedObject;
+    auto FedI = std::make_unique<helics::FedObject>();
     try
     {
-        fed->fedptr = std::make_shared<helics::ValueFederate>((json != nullptr) ? std::string(json) : std::string());
+        FedI->fedptr = std::make_shared<helics::ValueFederate>((json != nullptr) ? std::string(json) : std::string());
     }
     catch (const helics::RegistrationFailure &)
     {
-        delete fed;
         return nullptr;
     }
-    fed->index = getMasterHolder()->addFed(fed);
-    fed->type = helics::vtype::valueFed;
-    fed->valid = fedValidationIdentifier;
-    return reinterpret_cast<void *> (fed);
+    FedI->type = helics::vtype::valueFed;
+    FedI->valid = fedValidationIdentifier;
+    auto fed = reinterpret_cast<void *>(FedI.get());
+    getMasterHolder()->addFed(std::move(FedI));
+    return  (fed);
 }
 
 /* Creation and destruction of Federates */
 helics_federate helicsCreateMessageFederate (const helics_federate_info_t fi)
 {
-    auto *fed = new helics::FedObject;
+    auto FedI = std::make_unique<helics::FedObject>();
     try
     {
         if (fi == nullptr)
         {
-            fed->fedptr = std::make_shared<helics::MessageFederate>(helics::FederateInfo());
+            FedI->fedptr = std::make_shared<helics::MessageFederate>(helics::FederateInfo());
         }
         else
         {
-            fed->fedptr = std::make_shared<helics::MessageFederate>(*reinterpret_cast<helics::FederateInfo *> (fi));
+            FedI->fedptr = std::make_shared<helics::MessageFederate>(*reinterpret_cast<helics::FederateInfo *> (fi));
         }
     }
     catch (const helics::RegistrationFailure &)
     {
-        delete fed;
         return nullptr;
     }
-    
-    fed->index = getMasterHolder()->addFed(fed);
-    fed->type = helics::vtype::messageFed;
-    fed->valid = fedValidationIdentifier;
-    return reinterpret_cast<void *> (fed);
+    FedI->type = helics::vtype::messageFed;
+    FedI->valid = fedValidationIdentifier;
+    auto fed = reinterpret_cast<void *>(FedI.get());
+    getMasterHolder()->addFed(std::move(FedI));
+    return  (fed);
 }
 
 helics_federate helicsCreateMessageFederateFromJson (const char *json)
 {
-    auto *fed = new helics::FedObject;
+    auto FedI = std::make_unique<helics::FedObject>();
     
     try
     {
-        fed->fedptr = std::make_shared<helics::MessageFederate>((json != nullptr) ? std::string(json) : std::string());
+        FedI->fedptr = std::make_shared<helics::MessageFederate>((json != nullptr) ? std::string(json) : std::string());
     }
     catch (const helics::RegistrationFailure &)
     {
-        delete fed;
         return nullptr;
     }
-    fed->index = getMasterHolder()->addFed(fed);
-    fed->type = helics::vtype::messageFed;
-    fed->valid = fedValidationIdentifier;
-    return reinterpret_cast<void *> (fed);
+    FedI->type = helics::vtype::messageFed;
+    FedI->valid = fedValidationIdentifier;
+    auto fed = reinterpret_cast<void *>(FedI.get());
+    getMasterHolder()->addFed(std::move(FedI));
+    return  (fed);
 }
 
 /* Creation and destruction of Federates */
 helics_federate helicsCreateCombinationFederate (const helics_federate_info_t fi)
 {
-    auto *fed = new helics::FedObject;
+    auto FedI = std::make_unique<helics::FedObject>();
     try
     {
         if (fi == nullptr)
         {
-            fed->fedptr = std::make_shared<helics::CombinationFederate>(helics::FederateInfo());
+            FedI->fedptr = std::make_shared<helics::CombinationFederate>(helics::FederateInfo());
         }
         else
         {
-            fed->fedptr = std::make_shared<helics::CombinationFederate>(*reinterpret_cast<helics::FederateInfo *> (fi));
+            FedI->fedptr = std::make_shared<helics::CombinationFederate>(*reinterpret_cast<helics::FederateInfo *> (fi));
         }
     }
     catch (const helics::RegistrationFailure &)
     {
-        delete fed;
         return nullptr;
     }
-    fed->index = getMasterHolder()->addFed(fed);
-    fed->type = helics::vtype::combinationFed;
-    fed->valid = fedValidationIdentifier;
-    return reinterpret_cast<void *> (fed);
+    FedI->type = helics::vtype::combinationFed;
+    FedI->valid = fedValidationIdentifier;
+    auto fed = reinterpret_cast<void *>(FedI.get());
+    getMasterHolder()->addFed(std::move(FedI));
+    return  (fed);
 }
 
 helics_federate helicsCreateCombinationFederateFromJson (const char *json)
 {
-    auto *fed = new helics::FedObject;
+    auto FedI = std::make_unique<helics::FedObject>();
     try
     {
-        fed->fedptr = std::make_shared<helics::CombinationFederate>((json != nullptr) ? std::string(json) : std::string());
+       FedI->fedptr = std::make_shared<helics::CombinationFederate>((json != nullptr) ? std::string(json) : std::string());
     }
     catch (const helics::RegistrationFailure &)
     {
-        delete fed;
         return nullptr;
     }
     
-    fed->index = getMasterHolder()->addFed(fed);
-    fed->type = helics::vtype::combinationFed;
-    fed->valid = fedValidationIdentifier;
-    return reinterpret_cast<void *> (fed);
+    FedI->type = helics::vtype::combinationFed;
+    FedI->valid = fedValidationIdentifier;
+    auto fed = reinterpret_cast<void *>(FedI.get());
+    getMasterHolder()->addFed(std::move(FedI));
+    return  (fed);
 }
 
 helics_federate helicsFederateClone (helics_federate fed)
@@ -231,12 +230,14 @@ helics_federate helicsFederateClone (helics_federate fed)
         return nullptr;
     }
     auto *fedObj = reinterpret_cast<helics::FedObject *> (fed);
-    auto *fedClone = new helics::FedObject;
+    auto fedClone = std::make_unique<helics::FedObject>();
     fedClone->fedptr = fedObj->fedptr;
-    fedClone->index = getMasterHolder ()->addFed (fedClone);
+   
     fedClone->type = fedObj->type;
     fedClone->valid = fedObj->valid;
-    return reinterpret_cast<void *> (fedClone);
+    auto fedB = reinterpret_cast<void *>(fedClone.get());
+    getMasterHolder()->addFed(std::move(fedClone));
+    return  (fedB);
 }
 
 helics_core helicsFederateGetCoreObject (helics_federate fed)
@@ -246,11 +247,12 @@ helics_core helicsFederateGetCoreObject (helics_federate fed)
     {
         return nullptr;
     }
-    auto *core = new helics::CoreObject;
-    core->index = getMasterHolder ()->addCore (core);
+    auto core = std::make_unique<helics::CoreObject>(); 
     core->valid = fedValidationIdentifier;
     core->coreptr = fedObj->getCorePointer ();
-    return reinterpret_cast<helics_core> (core);
+    auto retcore = reinterpret_cast<helics_core> (core.get());
+    getMasterHolder()->addCore(std::move(core));
+    return retcore;
 }
 
 helics_status helicsFederateFinalize (helics_federate fed)

--- a/src/helics/shared_api_library/helicsExport.cpp
+++ b/src/helics/shared_api_library/helicsExport.cpp
@@ -293,12 +293,14 @@ helics_core helicsCreateCore (const char *type, const char *name, const char *in
     {
         return nullptr;
     }
-    auto *core = new helics::CoreObject;
-    core->index = getMasterHolder ()->addCore (core);
+    auto core = std::make_unique<helics::CoreObject>();
     core->valid = coreValidationIdentifier;
     core->coreptr = helics::CoreFactory::FindOrCreate (ct, (name != nullptr) ? std::string (name) : nullstr,
                                                        (initString != nullptr) ? std::string (initString) : nullstr);
-    return reinterpret_cast<helics_core> (core);
+    auto retcore = reinterpret_cast<helics_core> (core.get());
+    getMasterHolder()->addCore(std::move(core));
+   
+    return retcore;
 }
 
 helics_core helicsCreateCoreFromArgs (const char *type, const char *name, int argc, const char *const *argv)
@@ -312,11 +314,14 @@ helics_core helicsCreateCoreFromArgs (const char *type, const char *name, int ar
     {
         return nullptr;
     }
-    auto *core = new helics::CoreObject;
-    core->index = getMasterHolder ()->addCore (core);
+    auto core = std::make_unique<helics::CoreObject>();
+    
     core->valid = coreValidationIdentifier;
     core->coreptr = helics::CoreFactory::FindOrCreate (ct, (name != nullptr) ? std::string (name) : nullstr, argc, argv);
-    return reinterpret_cast<helics_core> (core);
+    auto retcore = reinterpret_cast<helics_core> (core.get());
+    getMasterHolder()->addCore(std::move(core));
+    
+    return retcore;
 }
 
 helics_core helicsCoreClone (helics_core core)
@@ -326,11 +331,13 @@ helics_core helicsCoreClone (helics_core core)
         return nullptr;
     }
     auto *coreObj = reinterpret_cast<helics::CoreObject *> (core);
-    auto *coreClone = new helics::CoreObject;
-    coreClone->index = getMasterHolder ()->addCore (coreClone);
+    auto coreClone = std::make_unique<helics::CoreObject>();
     coreClone->valid = coreValidationIdentifier;
     coreClone->coreptr = coreObj->coreptr;
-    return reinterpret_cast<helics_core> (coreClone);
+    auto retcore = reinterpret_cast<helics_core> (coreClone.get());
+    getMasterHolder()->addCore(std::move(coreClone));
+    
+    return retcore;
 }
 
 helics_federate helicsGetFederateByName (const char *fedName)
@@ -354,12 +361,13 @@ helics_broker helicsCreateBroker (const char *type, const char *name, const char
     {
         return nullptr;
     }
-    auto broker = new helics::BrokerObject;
-    broker->index = getMasterHolder ()->addBroker (broker);
+    auto broker = std::make_unique<helics::BrokerObject>(); 
     broker->valid = brokerValidationIdentifier;
     broker->brokerptr = helics::BrokerFactory::create (ct, (name != nullptr) ? std::string (name) : nullstr,
                                                        (initString != nullptr) ? std::string (initString) : nullstr);
-    return reinterpret_cast<helics_broker> (broker);
+    auto retbroker = reinterpret_cast<helics_broker> (broker.get());
+    getMasterHolder()->addBroker(std::move(broker));
+    return retbroker;
 }
 
 helics_broker helicsCreateBrokerFromArgs (const char *type, const char *name, int argc, const char *const *argv)
@@ -373,11 +381,12 @@ helics_broker helicsCreateBrokerFromArgs (const char *type, const char *name, in
     {
         return nullptr;
     }
-    auto *broker = new helics::BrokerObject;
-    broker->index = getMasterHolder ()->addBroker (broker);
+    auto broker = std::make_unique<helics::BrokerObject>();
     broker->valid = brokerValidationIdentifier;
     broker->brokerptr = helics::BrokerFactory::create (ct, (name != nullptr) ? std::string (name) : nullstr, argc, argv);
-    return reinterpret_cast<helics_broker> (broker);
+    auto retbroker = reinterpret_cast<helics_broker> (broker.get());
+    getMasterHolder()->addBroker(std::move(broker));
+    return retbroker;
 }
 
 helics_broker helicsBrokerClone (helics_broker broker)
@@ -387,11 +396,12 @@ helics_broker helicsBrokerClone (helics_broker broker)
         return nullptr;
     }
     auto *brokerObj = reinterpret_cast<helics::BrokerObject *> (broker);
-    auto *brokerClone = new helics::BrokerObject;
-    brokerClone->index = getMasterHolder ()->addBroker (brokerClone);
+    auto brokerClone = std::make_unique<helics::BrokerObject>();
     brokerClone->valid = brokerValidationIdentifier;
     brokerClone->brokerptr = brokerObj->brokerptr;
-    return reinterpret_cast<helics_broker> (brokerClone);
+    auto retbroker = reinterpret_cast<helics_broker> (brokerClone.get());
+    getMasterHolder()->addBroker(std::move(brokerClone));
+    return retbroker;
 }
 
 helics_bool_t helicsBrokerIsConnected (helics_broker broker)
@@ -547,7 +557,6 @@ void helicsCoreFree (helics_core core)
     if (coreObj != nullptr)
     {
         getMasterHolder ()->clearCore (coreObj->index);
-        delete coreObj;
     }
     helics::CoreFactory::cleanUpCores ();
 }
@@ -558,7 +567,6 @@ void helicsBrokerFree (helics_broker broker)
     if (brokerObj != nullptr)
     {
         getMasterHolder ()->clearBroker (brokerObj->index);
-        delete brokerObj;
     }
     helics::BrokerFactory::cleanUpBrokers ();
 }
@@ -569,7 +577,6 @@ void helicsFederateFree (helics_federate fed)
     if (fedObj != nullptr)
     {
         getMasterHolder ()->clearFed (fedObj->index);
-        delete fedObj;
     }
 
     helics::CoreFactory::cleanUpCores ();
@@ -746,40 +753,43 @@ MasterObjectHolder::~MasterObjectHolder ()
     deleteAll ();
     // std::cout << "end of master Object Holder destructor" << std::endl;
 }
-int MasterObjectHolder::addBroker (helics::BrokerObject *broker)
+int MasterObjectHolder::addBroker (std::unique_ptr<helics::BrokerObject> broker)
 {
     auto handle = brokers.lock ();
     auto index = static_cast<int> (handle->size ());
-    handle->push_back (broker);
+    broker->index = index;
+    handle->push_back (std::move(broker));
     return index;
 }
 
-int MasterObjectHolder::addCore (helics::CoreObject *core)
+int MasterObjectHolder::addCore (std::unique_ptr<helics::CoreObject> core)
 {
     auto handle = cores.lock ();
     auto index = static_cast<int> (handle->size ());
-    handle->push_back (core);
+    core->index = index;
+    handle->push_back (std::move(core));
     return index;
 }
 
-int MasterObjectHolder::addFed (helics::FedObject *fed)
+int MasterObjectHolder::addFed (std::unique_ptr<helics::FedObject> fed)
 {
     auto handle = feds.lock ();
     auto index = static_cast<int> (handle->size ());
-    handle->push_back (fed);
+    fed->index = index;
+    handle->push_back (std::move(fed));
     return index;
 }
 
 helics::FedObject *MasterObjectHolder::findFed (const std::string &fedName)
 {
     auto handle = feds.lock ();
-    for (auto fed : (*handle))
+    for (auto &fed : (*handle))
     {
         if (fed->fedptr)
         {
             if (fed->fedptr->getName () == fedName)
             {
-                return fed;
+                return fed.get();
             }
         }
     }
@@ -821,25 +831,13 @@ void MasterObjectHolder::deleteAll ()
     }
     {
         auto brokerHandle = brokers.lock ();
-        for (auto obj : *brokerHandle)
-        {
-            delete obj;
-        }
         brokerHandle->clear ();
     }
     {
         auto coreHandle = cores.lock ();
-        for (auto obj : *coreHandle)
-        {
-            delete obj;
-        }
         coreHandle->clear ();
     }
     auto fedHandle = feds.lock ();
-    for (auto obj : *fedHandle)
-    {
-        delete obj;
-    }
     fedHandle->clear ();
 }
 

--- a/src/helics/shared_api_library/internal/api_objects.h
+++ b/src/helics/shared_api_library/internal/api_objects.h
@@ -1,12 +1,9 @@
-
 /*
 Copyright © 2017-2018,
 Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC
 All rights reserved. See LICENSE file and DISCLAIMER for more details.
 */
 
-#ifndef HELICS_API_OBJECTS_H_
-#define HELICS_API_OBJECTS_H_
 #pragma once
 
 #include <memory>
@@ -71,7 +68,6 @@ namespace helics
     class SubscriptionObject;
     class PublicationObject;
     class EndpointObject;
-
 
 	/** object wrapping a federate for the c-api*/
 	class FedObject
@@ -169,17 +165,17 @@ std::shared_ptr<helics::Core> getCoreSharedPtr(helics_core core);
 class MasterObjectHolder
 {
 private:
-    guarded<std::vector<helics::BrokerObject *>> brokers;
-    guarded<std::vector<helics::CoreObject *>> cores;
-    guarded<std::vector<helics::FedObject *>> feds;
+    guarded<std::vector<std::unique_ptr<helics::BrokerObject>>> brokers;
+    guarded<std::vector<std::unique_ptr<helics::CoreObject>>> cores;
+    guarded<std::vector<std::unique_ptr<helics::FedObject>>> feds;
     tripwire::TripWireDetector tripDetect;
 public:
     MasterObjectHolder() noexcept;
     ~MasterObjectHolder();
     helics::FedObject *findFed(const std::string &fedName);
-    int addBroker(helics::BrokerObject * broker);
-    int addCore(helics::CoreObject *core);
-    int addFed(helics::FedObject *fed);
+    int addBroker(std::unique_ptr<helics::BrokerObject> broker);
+    int addCore(std::unique_ptr<helics::CoreObject> core);
+    int addFed(std::unique_ptr<helics::FedObject> fed);
     void clearBroker(int index);
     void clearCore(int index);
     void clearFed(int index);
@@ -188,6 +184,4 @@ public:
 
 std::shared_ptr<MasterObjectHolder> getMasterHolder();
 void clearAllObjects();
-
-#endif
 

--- a/swig/python2/CMakeLists.txt
+++ b/swig/python2/CMakeLists.txt
@@ -51,13 +51,6 @@ add_custom_command(TARGET _helics POST_BUILD        # Adds a post-build event to
         "$<TARGET_FILE_DIR:_helics>/")                 # <--this is out-file path
 endforeach(keyfile)
 
-add_custom_command(TARGET _helics2 POST_BUILD        # Adds a post-build event to api tests
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different  # which executes "cmake - E copy_if_different..."
-        "$<TARGET_FILE:helicsSharedLib>"      # <--this is in-file
-        "$<TARGET_FILE_DIR:_helics>/")                 # <--this is out-file path
-		
-
-
 
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/helics.py DESTINATION python COMPONENT python)
 INSTALL(FILES $<TARGET_FILE:helicsSharedLib> DESTINATION python COMPONENT python)

--- a/tests/helics/application_api/ErrorTests.cpp
+++ b/tests/helics/application_api/ErrorTests.cpp
@@ -46,4 +46,33 @@ BOOST_AUTO_TEST_CASE (duplicate_federate_names2)
     broker->disconnect ();
 }
 
+
+BOOST_AUTO_TEST_CASE(already_init_broker)
+{
+    auto broker = AddBroker("test", 1);
+    AddFederates<helics::ValueFederate>("test", 1, broker, 1.0, "fed");
+    auto fed1 = GetFederateAs<helics::ValueFederate>(0);
+
+    fed1->enterInitializationState();
+    helics::FederateInfo fi("fed222",helics::core_type::TEST);
+    fi.coreInitString=std::string("--broker=") + broker->getIdentifier();
+    BOOST_CHECK_THROW(helics::ValueFederate fed3(fi), helics::RegistrationFailure);
+    broker->disconnect();
+
+}
+
+BOOST_AUTO_TEST_CASE(already_init_core)
+{
+    auto broker = AddBroker("test", 1);
+    AddFederates<helics::ValueFederate>("test", 1, broker, 1.0, "fed");
+
+    auto fed1 = GetFederateAs<helics::ValueFederate>(0);
+    fed1->enterExecutionState();
+    helics::FederateInfo fi("fed2");
+    // get the core pointer from fed2 and using the name of fed1 should be an error
+    BOOST_CHECK_THROW(helics::ValueFederate fed2(fed1->getCorePointer(), fi), helics::RegistrationFailure);
+    broker->disconnect();
+
+}
+
 BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/helics/core/CMakeLists.txt
+++ b/tests/helics/core/CMakeLists.txt
@@ -29,6 +29,7 @@ data-block-tests.cpp
 UdpCore-tests.cpp
 ForwardingTimeCoordinatorTests.cpp
 TimeCoordinatorTests.cpp
+networkInfoTests.cpp
 )
 
 if (NOT DISABLE_TCP_CORE)

--- a/tests/helics/core/networkInfoTests.cpp
+++ b/tests/helics/core/networkInfoTests.cpp
@@ -1,0 +1,59 @@
+/*
+Copyright © 2017-2018,
+Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC
+All rights reserved. See LICENSE file and DISCLAIMER for more details.
+*/
+#include "testFixtures.h"
+#include <boost/test/unit_test.hpp>
+
+#include "helics/core/NetworkBrokerData.hpp"
+#include "helics/common/stringToCmdLine.h"
+
+BOOST_AUTO_TEST_SUITE(networkData_tests)
+
+BOOST_AUTO_TEST_CASE(basic_test)
+{
+    helics::NetworkBrokerData bdata;
+    StringToCmdLine cmd("--broker=bob --interface=harry --ipv4");
+    bdata.initializeFromArgs(cmd.getArgCount(), cmd.getArgV(), "local");
+    BOOST_CHECK_EQUAL(bdata.brokerAddress, "bob");
+    BOOST_CHECK_EQUAL(bdata.localInterface, "harry");
+    BOOST_CHECK(bdata.interfaceNetwork == helics::interface_networks::ipv4);
+    StringToCmdLine cmd2("--brokername=tom --brokerport=20755 --port 45");
+    bdata.initializeFromArgs(cmd2.getArgCount(), cmd2.getArgV(), "local");
+    BOOST_CHECK_EQUAL(bdata.brokerName, "tom");
+    BOOST_CHECK_EQUAL(bdata.brokerPort, 20755);
+    BOOST_CHECK_EQUAL(bdata.portNumber, 45);
+}
+
+
+BOOST_AUTO_TEST_CASE(add_check_detection)
+{
+    BOOST_CHECK(helics::isipv6("FEDC:BA98:7654:3210:FEDC:BA98:7654:3210"));
+    BOOST_CHECK(helics::isipv6("::192.9.5.5"));
+    BOOST_CHECK(helics::isipv6("http://[1080::8:800:200C:417A]/foo"));
+    BOOST_CHECK(helics::isipv6("::0"));
+    BOOST_CHECK(!helics::isipv6("192.9.5.5"));
+    BOOST_CHECK(!helics::isipv6("tcp://192.9.5.5:80"));
+}
+
+BOOST_AUTO_TEST_CASE(local_address_test)
+{
+    auto netw = helics::getLocalExternalAddressV4();
+    BOOST_CHECK(!helics::isipv6(netw));
+    BOOST_CHECK(!netw.empty());
+    auto netw2 = helics::getLocalExternalAddressV4("www.google.com");
+    BOOST_CHECK(!helics::isipv6(netw2));
+    BOOST_CHECK(!netw2.empty());
+}
+
+BOOST_AUTO_TEST_CASE(local_address_testv6)
+{
+    auto netw = helics::getLocalExternalAddressV6();
+    BOOST_CHECK(!netw.empty());
+    BOOST_CHECK(helics::isipv6(netw));
+    auto netw2 = helics::getLocalExternalAddressV6("2001:db8::1");
+    BOOST_CHECK(helics::isipv6(netw2));
+    BOOST_CHECK(!netw2.empty());
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/java_helics/ApplicationApiTest.java
+++ b/tests/java_helics/ApplicationApiTest.java
@@ -8,7 +8,7 @@ import com.java.helics.helics;
 import com.java.helics.helics_status;
 
 public class ApplicationApiTest {
-	
+
 	public static SWIGTYPE_p_void createValueFederate(final String fedName, final double timeDelta) {
 		SWIGTYPE_p_void fi = helics.helicsFederateInfoCreate();
 		helics_status rv = helics.helicsFederateInfoSetFederateName(fi,fedName);
@@ -18,7 +18,7 @@ public class ApplicationApiTest {
 		SWIGTYPE_p_void valFed = helics.helicsCreateValueFederate(fi);
 		return valFed;
 	}
-	
+
 	public static void main(String[] args) {
         SWIGTYPE_p_void broker = helics.helicsCreateBroker("zmq", "", "1");
         SWIGTYPE_p_void myFederate = ApplicationApiTest.createValueFederate("javaFederate", 1);
@@ -51,6 +51,6 @@ public class ApplicationApiTest {
 		// we have exited our time loop so we are done simulating. Lets exit the co-simulation.
 		rv = helics.helicsFederateFinalize(myFederate);
 		System.out.println(String.format("%s has successfully exited the co-simulation.", "javaFederate"));
+		helics.helicsCloseLibrary();
 	}
 }
-

--- a/tests/python_helics/test_message_filter.py
+++ b/tests/python_helics/test_message_filter.py
@@ -135,3 +135,4 @@ def test_message_filter_function(broker):
 
     FreeFederate(fFed)
     FreeFederate(mFed)
+    time.sleep(1.0)


### PR DESCRIPTION
This improves the autodetection for the local interfaces.  For cores/brokers that link with a broker, the network should be detected based on the broker.  For root brokers.  it will still default to local, but a flag like --ipv4 or --ipv6 or --all can be specified to simplify the network connection interface.  without requiring --interface=XXX.XXX.XXX.XXX:port or something to that effect.  zmq will default to using tcp

