### PR TITLE
Remove dependency on Travis for CI dependency installation script

### DIFF
--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # Set variables based on build environment
-WAIT_COMMAND=''
 if [[ "$TRAVIS" == "true" ]]; then
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         HOMEBREW_NO_AUTO_UPDATE=1 brew install pcre
@@ -21,7 +20,6 @@ if [[ "$TRAVIS" == "true" ]]; then
     fi
 else
     export CI_DEPENDENCY_DIR=$1
-    WAIT_COMMAND=wait
     commit_msg=""
     os_name="$(uname -s)"
 fi

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
 # Set variables based on build environment
+WAIT_COMMAND=''
 if [[ "$TRAVIS" == "true" ]]; then
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         HOMEBREW_NO_AUTO_UPDATE=1 brew install pcre
     fi
 
     export CI_DEPENDENCY_DIR=${TRAVIS_BUILD_DIR}/dependencies
+    
+    WAIT_COMMAND=travis_wait
 
     # Convert commit message to lower case
     commit_msg=$(tr '[:upper:]' '[:lower:]' <<< ${TRAVIS_COMMIT_MESSAGE})
@@ -18,6 +21,7 @@ if [[ "$TRAVIS" == "true" ]]; then
     fi
 else
     export CI_DEPENDENCY_DIR=$1
+    WAIT_COMMAND=wait
     commit_msg=""
     os_name="$(uname -s)"
 fi
@@ -119,7 +123,7 @@ if [[ "$USE_MPI" ]]; then
     if [[ ! -d "${mpi_install_path}" ]]; then
         # if mpi_implementation isn't set, then the mpi implementation requested wasn't recognized
         if [[ ! -z "${mpi_implementation}" ]]; then
-            travis_wait ./scripts/install-dependency.sh ${mpi_implementation} ${mpi_version} ${mpi_install_path}
+            ${WAIT_COMMAND} ./scripts/install-dependency.sh ${mpi_implementation} ${mpi_version} ${mpi_install_path}
         fi
     fi
 fi
@@ -127,7 +131,7 @@ fi
 # Install Boost
 if [[ ! -d "${boost_install_path}" ]]; then
     echo "*** build boost"
-    travis_wait ./scripts/install-dependency.sh boost ${boost_version} ${boost_install_path}
+    ${WAIT_COMMAND} ./scripts/install-dependency.sh boost ${boost_version} ${boost_install_path}
     echo "*** built boost successfully"
 fi
 

--- a/scripts/install-dependency.sh
+++ b/scripts/install-dependency.sh
@@ -250,7 +250,7 @@ case "$1" in
         echo "$0 zmq [version=HEAD] install_path"
 esac
 
-# Return to the original direcotry and get rid of the temp directory
+# Return to the original directory and get rid of the temp directory
 popd
 rm -rf ${dependency_temp_dir}
 


### PR DESCRIPTION
* Dependency installation script used on Travis can be run on other systems to build the full set of dependencies with the same versions as used on Travis