### PR TITLE
get the proper string length for vector in the C api and interface API's

### DIFF
--- a/src/helics/application_api/Subscriptions.cpp
+++ b/src/helics/application_api/Subscriptions.cpp
@@ -164,13 +164,36 @@ size_t Subscription::getRawSize ()
 size_t Subscription::getStringSize () 
 { 
     getAndCheckForUpdate();
+    if (lastValue.index() == stringLoc)
+    {
+        return mpark::get<std::string>(lastValue).size();
+    }
+    else if (lastValue.index() == namedPointLoc)
+    {
+        const auto &np= mpark::get<named_point>(lastValue);
+        return np.name.size();
+    }
     auto out = getValue<std::string>();
-    return out.size()+1;
+    return out.size();
 }
 
 size_t Subscription::getVectorSize () 
 { 
     getAndCheckForUpdate();
+    switch (lastValue.index())
+    {
+    case doubleLoc:
+    case intLoc:
+        return 1;
+    case complexLoc:
+        return 2;
+    case vectorLoc:
+        return mpark::get<std::vector<double>>(lastValue).size();
+    case complexVectorLoc:
+        return mpark::get<std::vector<std::complex<double>>>(lastValue).size() * 2;
+    default:
+        break;
+    }
     auto out = getValue<std::vector<double>>();
     return out.size();
 }

--- a/src/helics/shared_api_library/ValueFederate.h
+++ b/src/helics/shared_api_library/ValueFederate.h
@@ -228,7 +228,7 @@ HELICS_EXPORT helics_status helicsPublicationPublishNamedPoint(helics_publicatio
 and vice versa,  not all translations make that much sense but they do work.
 * @{
 */
-/** get the size of a value for subscription,  this is useful for strings and raw data
+/** get the size of the raw value for subscription
 @returns the size of the raw data/string in bytes
 */
 HELICS_EXPORT int helicsSubscriptionGetValueSize (helics_subscription sub);
@@ -241,6 +241,11 @@ HELICS_EXPORT int helicsSubscriptionGetValueSize (helics_subscription sub);
 @return a helics_status value, helics_ok if everything went fine
 */
 HELICS_EXPORT helics_status helicsSubscriptionGetRawValue (helics_subscription sub, void *data, int maxlen, int *actualLength);
+
+/** get the size of a value for subscription assuming return as a string
+@returns the size of the string
+*/
+HELICS_EXPORT int helicsSubscriptionGetStringSize(helics_subscription sub);
 
 /** get a string value from a subscription
 @param sub the subscription to get the data for

--- a/src/helics/shared_api_library/ValueFederateExport.cpp
+++ b/src/helics/shared_api_library/ValueFederateExport.cpp
@@ -788,6 +788,23 @@ int helicsSubscriptionGetVectorSize (helics_subscription sub)
     return static_cast<int> (subObj->subptr->getVectorSize());
 }
 
+int helicsSubscriptionGetStringSize(helics_subscription sub)
+{
+    if (sub == nullptr)
+    {
+        return 0;
+    }
+    auto subObj = reinterpret_cast<helics::SubscriptionObject *> (sub);
+    if (subObj->rawOnly)
+    {
+        auto str = subObj->fedptr->getValue<std::string>(subObj->id);
+        return static_cast<int> (str.size())+1;
+    }
+
+    return static_cast<int> (subObj->subptr->getStringSize())+1;
+}
+
+
 helics_status helicsSubscriptionGetVector (helics_subscription sub, double data[], int maxlen, int *actualSize)
 {
     if (sub == nullptr)

--- a/swig/java/interface/helics.java
+++ b/swig/java/interface/helics.java
@@ -454,6 +454,10 @@ public class helics implements helicsConstants {
     return helics_status.swigToEnum(helicsJNI.helicsSubscriptionGetRawValue(SWIGTYPE_p_void.getCPtr(sub), SWIGTYPE_p_void.getCPtr(data), maxlen, actualLength));
   }
 
+  public static int helicsSubscriptionGetStringSize(SWIGTYPE_p_void sub) {
+    return helicsJNI.helicsSubscriptionGetStringSize(SWIGTYPE_p_void.getCPtr(sub));
+  }
+
   public static helics_status helicsSubscriptionGetString(SWIGTYPE_p_void sub, byte[] outputString, int[] actualLength) {
     return helics_status.swigToEnum(helicsJNI.helicsSubscriptionGetString(SWIGTYPE_p_void.getCPtr(sub), outputString, actualLength));
   }

--- a/swig/java/interface/helicsJNI.java
+++ b/swig/java/interface/helicsJNI.java
@@ -161,6 +161,7 @@ public class helicsJNI {
   public final static native int helicsPublicationPublishNamedPoint(long jarg1, String jarg2, double jarg3);
   public final static native int helicsSubscriptionGetValueSize(long jarg1);
   public final static native int helicsSubscriptionGetRawValue(long jarg1, long jarg2, int jarg3, int[] jarg4);
+  public final static native int helicsSubscriptionGetStringSize(long jarg1);
   public final static native int helicsSubscriptionGetString(long jarg1, byte[] jarg2, int[] jarg4);
   public final static native int helicsSubscriptionGetInteger(long jarg1, long[] jarg2);
   public final static native int helicsSubscriptionGetBoolean(long jarg1, int[] jarg2);

--- a/swig/java/interface/helicsJavaJAVA_wrap.c
+++ b/swig/java/interface/helicsJavaJAVA_wrap.c
@@ -3008,6 +3008,20 @@ SWIGEXPORT jint JNICALL Java_com_java_helics_helicsJNI_helicsSubscriptionGetRawV
 }
 
 
+SWIGEXPORT jint JNICALL Java_com_java_helics_helicsJNI_helicsSubscriptionGetStringSize(JNIEnv *jenv, jclass jcls, jlong jarg1) {
+  jint jresult = 0 ;
+  helics_subscription arg1 = (helics_subscription) 0 ;
+  int result;
+  
+  (void)jenv;
+  (void)jcls;
+  arg1 = *(helics_subscription *)&jarg1; 
+  result = (int)helicsSubscriptionGetStringSize(arg1);
+  jresult = (jint)result; 
+  return jresult;
+}
+
+
 SWIGEXPORT jint JNICALL Java_com_java_helics_helicsJNI_helicsSubscriptionGetString(JNIEnv *jenv, jclass jcls, jlong jarg1, jbyteArray jarg2, jintArray jarg4) {
   jint jresult = 0 ;
   helics_subscription arg1 = (helics_subscription) 0 ;

--- a/swig/java/java_maps.i
+++ b/swig/java/java_maps.i
@@ -26,7 +26,7 @@
 //}
 //
 //%typemap(check)(char *outputString, int maxStringlen, int *actualLength) {
-//    $2=helicsSubscriptionGetValueSize(arg1)+2;
+//    $2=helicsSubscriptionGetStringSize(arg1)+2;
 //    $1 = (char *) malloc($2);
 //}
 //

--- a/swig/matlab/matlab_maps.i
+++ b/swig/matlab/matlab_maps.i
@@ -24,7 +24,7 @@
 }
 
 %typemap(check)(char *outputString, int maxStringlen, int *actualLength) {
-    $2=helicsSubscriptionGetValueSize(arg1)+2;
+    $2=helicsSubscriptionGetStringSize(arg1)+2;
     $1 = (char *) malloc($2);
 }
 

--- a/swig/python/helics.py
+++ b/swig/python/helics.py
@@ -1254,7 +1254,7 @@ def helicsFederateSetLoggingLevel(fed: 'helics_federate', loggingLevel: 'int') -
     """
     return _helics.helicsFederateSetLoggingLevel(fed, loggingLevel)
 
-def helicsFederateSetMaxIterations(fi: 'helics_federate_info_t', maxIterations: 'int') -> "helics_status":
+def helicsFederateSetMaxIterations(fi: 'helics_federate', maxIterations: 'int') -> "helics_status":
     return _helics.helicsFederateSetMaxIterations(fi, maxIterations)
 helicsFederateSetMaxIterations = _helics.helicsFederateSetMaxIterations
 

--- a/swig/python/helics_wrap.c
+++ b/swig/python/helics_wrap.c
@@ -6196,7 +6196,7 @@ fail:
 
 SWIGINTERN PyObject *_wrap_helicsFederateSetMaxIterations(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  helics_federate_info_t arg1 = (helics_federate_info_t) 0 ;
+  helics_federate arg1 = (helics_federate) 0 ;
   int arg2 ;
   int res1 ;
   int val2 ;
@@ -6208,7 +6208,7 @@ SWIGINTERN PyObject *_wrap_helicsFederateSetMaxIterations(PyObject *SWIGUNUSEDPA
   if (!PyArg_ParseTuple(args,(char *)"OO:helicsFederateSetMaxIterations",&obj0,&obj1)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0,SWIG_as_voidptrptr(&arg1), 0, 0);
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "helicsFederateSetMaxIterations" "', argument " "1"" of type '" "helics_federate_info_t""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "helicsFederateSetMaxIterations" "', argument " "1"" of type '" "helics_federate""'"); 
   }
   ecode2 = SWIG_AsVal_int(obj1, &val2);
   if (!SWIG_IsOK(ecode2)) {

--- a/swig/python/python_maps.i
+++ b/swig/python/python_maps.i
@@ -25,7 +25,7 @@
 }
 
 %typemap(check)(char *outputString, int maxStringlen, int *actualLength) {
-    $2=helicsSubscriptionGetValueSize(arg1)+2;
+    $2=helicsSubscriptionGetStringSize(arg1)+2;
     $1 = (char *) malloc($2);
 }
 

--- a/swig/python2/python_maps2.i
+++ b/swig/python2/python_maps2.i
@@ -25,7 +25,7 @@
 }
 
 %typemap(check)(char *outputString, int maxStringlen, int *actualLength) {
-    $2=helicsSubscriptionGetValueSize(arg1)+2;
+    $2=helicsSubscriptionGetStringSize(arg1)+2;
     $1 = (char *) malloc($2);
 }
 


### PR DESCRIPTION
had to fix the swig maps, and add a function to the C api, that called the correct thing.  regenerated the python and java interfaces.  
@kdheepak The Matlab interface files will need to be regenerated before merging but I wanted to check this over through a PR first.  