### PR TITLE
Very small time checks

### DIFF
--- a/config/helics-config.h.in
+++ b/config/helics-config.h.in
@@ -19,6 +19,8 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 
 #cmakedefine BOOST_STATIC
 
+#cmakedefine HELICS_USE_PICOSECOND_TIME
+
 #define BOOST_VERSION_LEVEL @BOOST_VERSION_LEVEL@
 
 #define HELICS_VERSION_MAJOR ${HELICS_VERSION_MAJOR}

--- a/src/helics/common/DualMappedVector.hpp
+++ b/src/helics/common/DualMappedVector.hpp
@@ -3,7 +3,6 @@ Copyright © 2017-2018,
 Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC
 All rights reserved. See LICENSE file and DISCLAIMER for more details.
 */
-
 #pragma once
 #include "MapTraits.hpp"
 #include <algorithm>

--- a/src/helics/common/timeRepresentation.hpp
+++ b/src/helics/common/timeRepresentation.hpp
@@ -64,7 +64,9 @@ inline constexpr double pow2 (unsigned int exponent)
 {
     return (exponent == 0) ? 1.0 : (2.0 * pow2 (exponent - 1));
 }
-
+/** generate a quick rounding operation as constexpr
+@details doesn't deal with very large numbers appropriately so 
+assumes the numbers given are normal and within the type specified*/
 template <typename ITYPE>
 inline constexpr ITYPE quick_round(double val)
 {

--- a/src/helics/common/timeRepresentation.hpp
+++ b/src/helics/common/timeRepresentation.hpp
@@ -64,6 +64,12 @@ inline constexpr double pow2 (unsigned int exponent)
 {
     return (exponent == 0) ? 1.0 : (2.0 * pow2 (exponent - 1));
 }
+
+template <typename ITYPE>
+inline constexpr ITYPE quick_round(double val)
+{
+    return static_cast<ITYPE>((val>=0.0)?(val+0.5):(val-0.5));
+}
 /** prototype class for representing time
 @details implements time as a count of 1/2^N seconds
 this is done for performance because many mathematical operations are needed on the time and this way
@@ -178,7 +184,7 @@ class count_time
     static constexpr baseType epsilon () noexcept { return baseType (1); }
     static constexpr baseType convert (double t) noexcept
     {
-        return (t > -1e12) ? ((t < 1e12) ? (static_cast<baseType> (t * dFactor)) : maxVal ()) : minVal ();
+        return (t > -1e12) ? ((t < 1e12) ? (quick_round<baseType> (t * dFactor)) : maxVal ()) : minVal ();
     }
     static CHRONO_CONSTEXPR baseType convert (std::chrono::nanoseconds nsTime) noexcept
     {

--- a/src/helics/core/helics-time.hpp
+++ b/src/helics/core/helics-time.hpp
@@ -7,6 +7,7 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 
 #include "../common/timeRepresentation.hpp"
 #include "core-types.hpp"
+#include "helics/helics-config.h"
 #include <cstdint>
 /** @file
 @details defining the time representation to use throughout helics
@@ -18,7 +19,11 @@ namespace helics
  *
  * Class represents time in the core.
  */
+#ifdef HELICS_USE_PICOSECOND_TIME
+using Time = TimeRepresentation<count_time<12>>;
+#else
 using Time = TimeRepresentation<count_time<9>>;
+#endif
 
 constexpr Time timeZero = Time::zeroVal ();
 constexpr Time timeEpsilon = Time::epsilon ();

--- a/tests/helics/application_api/CMakeLists.txt
+++ b/tests/helics/application_api/CMakeLists.txt
@@ -32,6 +32,7 @@ subPubObjectTests.cpp
 ValueFederateAdditionalTests.cpp
 ErrorTests.cpp
 federateRealTimeTests.cpp
+TimingTests2.cpp
 )
 
 set(extended_test_sources

--- a/tests/helics/application_api/TimingTests2.cpp
+++ b/tests/helics/application_api/TimingTests2.cpp
@@ -1,0 +1,94 @@
+/*
+Copyright © 2017-2018,
+Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC
+All rights reserved. See LICENSE file and DISCLAIMER for more details.
+*/
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/floating_point_comparison.hpp>
+
+#include <complex>
+
+/** these test cases test out the value converters
+ */
+#include "helics/helics.hpp"
+#include "testFixtures.hpp"
+#include <future>
+BOOST_FIXTURE_TEST_SUITE (timing_tests2, FederateTestFixture)
+
+
+
+/** just a check that in the simple case we do actually get the time back we requested*/
+
+
+BOOST_AUTO_TEST_CASE (small_time_test)
+{
+    SetupTest<helics::ValueFederate> ("test", 2);
+    auto vFed1 = GetFederateAs<helics::ValueFederate> (0);
+    auto vFed2 = GetFederateAs<helics::ValueFederate> (1);
+
+    auto pub1_a = helics::make_publication<double> (helics::GLOBAL, vFed1, "pub1_a");
+    auto pub1_b = helics::make_publication<double>(helics::GLOBAL, vFed1, "pub1_b");
+    auto pub2_a = helics::make_publication<double>(helics::GLOBAL, vFed2, "pub2_a");
+    auto pub2_b = helics::make_publication<double>(helics::GLOBAL, vFed2, "pub2_b");
+    
+    
+    auto sub1_a = helics::Subscription( vFed2, "pub1_a");
+    auto sub1_b = helics::Subscription( vFed2, "pub1_b");
+    auto sub2_a = helics::Subscription( vFed1, "pub2_a");
+    auto sub2_b = helics::Subscription( vFed1, "pub2_b");
+    vFed1->enterExecutionStateAsync ();
+    vFed2->enterExecutionState ();
+    vFed1->enterExecutionStateComplete ();
+    auto echoRun = [&]() {helics::Time grantedTime = helics::timeZero;
+    helics::Time stopTime(100, timeUnits::ns);
+    while (grantedTime < stopTime)
+    {
+        grantedTime = vFed2->requestTime(stopTime);
+        if (sub1_a.isUpdated())
+        {
+            auto val = sub1_a.getValue<double>();
+            pub2_a->publish(val);
+        }
+        if (sub1_b.isUpdated())
+        {
+            auto val = sub1_b.getValue<double>();
+            pub2_b->publish(val);
+        }
+    }};
+    
+    auto fut = std::async(echoRun);
+    helics::Time grantedTime = helics::timeZero;
+    helics::Time requestedTime(10, timeUnits::ns);
+    helics::Time stopTime(100, timeUnits::ns);
+    while (grantedTime < stopTime)
+    {
+        grantedTime=vFed1->requestTime(requestedTime);
+        if (grantedTime == requestedTime)
+        {
+           
+            pub1_a->publish(10.3);
+            pub1_b->publish(11.2);
+            requestedTime += helics::Time(10, timeUnits::ns);
+        }
+        else
+        {
+            BOOST_CHECK(grantedTime == requestedTime - helics::Time(9, timeUnits::ns));
+            printf("grantedTime=%e\n", static_cast<double>(grantedTime));
+            if (sub2_a.isUpdated())
+            {
+                BOOST_CHECK_EQUAL(sub2_a.getValue<double>(), 10.3);
+            }
+            if (sub2_b.isUpdated())
+            {
+                BOOST_CHECK_EQUAL(sub2_b.getValue<double>(), 11.2);
+            }
+        }
+    }
+    vFed1->finalize ();
+    fut.get();
+    vFed2->finalize ();
+}
+
+
+BOOST_AUTO_TEST_SUITE_END ()

--- a/tests/helics/common/TimeTests.cpp
+++ b/tests/helics/common/TimeTests.cpp
@@ -100,6 +100,14 @@ BOOST_AUTO_TEST_CASE (test_math)
     BOOST_CHECK_EQUAL (time3, Time (2.0));
 }
 
+BOOST_AUTO_TEST_CASE(rounding_tests)
+{
+    BOOST_CHECK(Time(1.25e-9) == Time(1, timeUnits::ns));
+    BOOST_CHECK(Time(0.99e-9) == Time(1, timeUnits::ns));
+    BOOST_CHECK(Time(1.49e-9) == Time(1, timeUnits::ns));
+    BOOST_CHECK(Time(1.51e-9) == Time(2, timeUnits::ns));
+}
+
 BOOST_AUTO_TEST_CASE (comparison_tests)
 {
     BOOST_CHECK (Time (1.1) > Time (1.0));
@@ -173,4 +181,6 @@ BOOST_AUTO_TEST_CASE (test_string_conversions)
 
     BOOST_CHECK_THROW (loadTimeFromString ("happy"), std::invalid_argument);
 }
+
+
 BOOST_AUTO_TEST_SUITE_END ()


### PR DESCRIPTION
this PR fixes an issue reported about mismatching times when using very small increments in time.  The source of the issue was the rounding technique used to convert the time representation to doubles.  This issue has never arisen before due to most cases not using very small increments or doing the tests using them in C++.  

The changes here add a rounding operation to the conversion which rounds to the nearest ns instead of truncating.  It also adds a hidden option to use PICOSECOND timing, though such use would be incompatible with any part of HELICS using ns resolution