### PR TITLE
just to get a sample for package building on msys2

### DIFF
--- a/config/packaging/mingw-w64-helics/PKGBUILD
+++ b/config/packaging/mingw-w64-helics/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Philip Top <top1@llnl.gov>
+
+_realname=helics
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=2.0.0
+pkgrel=1
+pkgdesc="A C++ library for co-simulation"
+arch=('any')
+url="https://github.com/GMLC-TDC/HELICS-src"
+license=('BSD')
+makedepends=("${MINGW_PACKAGE_PREFIX}-gcc"
+             "${MINGW_PACKAGE_PREFIX}-cmake"
+			 "${MINGW_PACKAGE_PREFIX}-boost"
+			 "${MINGW_PACKAGE_PREFIX}-zeromq"
+			 "${MINGW_PACKAGE_PREFIX}-swig"
+             "${MINGW_PACKAGE_PREFIX}-python3")
+
+source=("${_realname}-${pkgver}.tar.gz"::"https://github.com/GMLC-TDC/HELICS-src/archive/v${pkgver}.tar.gz"
+        001-library-name.patch)
+#sha256sums=('c49deac9e0933bcb7044f08516861a2d560988540b23de2ac1ad443b219afdb6'
+ #           'db74c4fb0e5b98a8365a99060166cfff36a7eda97f552cd838b8a7bb9799428a')
+
+prepare() {
+  cd ${_realname}-v${pkgver}
+}
+
+build() {
+  declare -a extra_config
+  if check_option "debug" "n"; then
+    extra_config+=("-DCMAKE_BUILD_TYPE=Release")
+  else
+    extra_config+=("-DCMAKE_BUILD_TYPE=Debug")
+  fi
+
+  [[ -d ${srcdir}/build-${MINGW_CHOST} ]] && rm -rf ${srcdir}/build-${MINGW_CHOST}
+  mkdir "${srcdir}/build-${MINGW_CHOST}" && cd "${srcdir}/build-${MINGW_CHOST}"
+
+  MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
+  ${MINGW_PREFIX}/bin/cmake \
+    -G"MSYS Makefiles" \
+    -DCMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
+    -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_STATIC_LIBS=ON \
+	-DBUILD_TESTS=OFF \
+    ${extra_config} \
+    ../${_realname}-v${pkgver}
+
+  make
+}
+
+package() {
+  cd "${srcdir}/build-${MINGW_CHOST}"
+  make DESTDIR=${pkgdir} install
+}


### PR DESCRIPTION
This is mainly to create a place for putting packaging files.  I added an untested PKGBUILD for MSYS2 packaging.    The PKGBUILD file would get added to the mingw-64-package repo eventually.  Once the 2.0.0 release is settled a little so we have a good based to work from.  

@kdheepak  might be good to stick the conda files in the packaging folder just so we have a view of them in the main repo.  