### PR TITLE
Allow clang thread sanitizer cron build to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
   fast_finish: true
   allow_failures:
     - os: osx
-    - name: "Clang 4 Thread Sanitizer"
+    - name: "Clang*Sanitizer"
 
   include:
     # XCode 6.4, OS X 10.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ jobs:
   fast_finish: true
   allow_failures:
     - os: osx
+    - name: "Clang 4 Thread Sanitizer"
 
   include:
     # XCode 6.4, OS X 10.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
   fast_finish: true
   allow_failures:
     - os: osx
-    - name: "Clang*Sanitizer"
+    - name: "Clang 4 Thread Sanitizer"
 
   include:
     # XCode 6.4, OS X 10.10


### PR DESCRIPTION
* Issue #460 allowing clang thread sanitizer cron build as a failure
* Travis doesn't support wild cards for allowable failures, entry must be an exact match