### PR TITLE
Add install include path to imported helics-static and helics-shared cmake targets

### DIFF
--- a/src/helics/CMakeLists.txt
+++ b/src/helics/CMakeLists.txt
@@ -23,6 +23,10 @@ add_library(
 target_link_libraries(helics-static PUBLIC helics_base)
 # add and alias library to match the find_package
 add_library(HELICS::helics-static ALIAS helics-static)
+target_include_directories(
+  helics-static
+  INTERFACE $<TARGET_PROPERTY:helics_base_includes,INTERFACE_INCLUDE_DIRECTORIES>
+)
 if(BUILD_SHARED_LIBS)
   add_library(
     helics-shared
@@ -35,6 +39,10 @@ if(BUILD_SHARED_LIBS)
 
   add_library(HELICS::helics-shared ALIAS helics-shared)
   target_link_libraries(helics-shared PRIVATE helics_base)
+  target_include_directories(
+    helics-shared
+    INTERFACE $<TARGET_PROPERTY:helics_base_includes,INTERFACE_INCLUDE_DIRECTORIES>
+  )
 
   if(WIN32)
     set_target_properties(helics-shared PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)


### PR DESCRIPTION
- [x] I have reviewed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I agree to license my contributions under the same license as in this repository
- [x] I have verified that the tests pass

# Description
Adds the install include path as part of the interface for the helics-static and helics-shared CMake targets imported by projects using find_package in config mode to locate HELICS. Allows using only CMake targets without needing to use the HELICS_INCLUDE_DIR variable to add an include directory.
