### PR TITLE
Change PR template to use h3 instead of h1 in markdown

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,11 +10,11 @@ This fixes issue #123
 - [ ] I agree to license my contributions under the same license as in this repository
 - [ ] I have verified that the tests pass
 
-# Description
+### Description
 
 <!-- Describe your Pull Request here -->
 
-# Proposed changes
+### Proposed changes
 
 <!-- Describe the proposed changes of Pull Request here -->
 


### PR DESCRIPTION

### Description

Use `h3` instead of `h1` in Pull Request templates.