### PR TITLE
C# interface usability

### DIFF
--- a/interfaces/csharp/CMakeLists.txt
+++ b/interfaces/csharp/CMakeLists.txt
@@ -10,7 +10,7 @@ if(ENABLE_SWIG AND SWIG_EXECUTABLE)
 
   set_property(SOURCE helicsCsharp.i PROPERTY SWIG_MODULE_NAME csharp)
   #set_source_files_properties(helicsCsharp.i PROPERTIES SWIG_FLAGS "-outfile;helics.cs")
-  set(CMAKE_SWIG_FLAGS "-outfile;helics.cs;-namespace;gmlc.helics")
+  set(CMAKE_SWIG_FLAGS "-outfile;helics.cs;-namespace;gmlc")
 
   swig_add_library(CShelics TYPE MODULE LANGUAGE csharp SOURCES helicsCsharp.i)
 

--- a/interfaces/csharp/csharp_maps.i
+++ b/interfaces/csharp/csharp_maps.i
@@ -1,3 +1,17 @@
+%typemap(in, numinputs=0) helics_error * (helics_error etemp) {
+	etemp=helicsErrorInitialize();
+	$1=&etemp;
+}
+
+%typemap(freearg) helics_error *
+{
+	if ($1->error_code!=helics_ok)
+	{
+		SWIG_CSharpSetPendingException(SWIG_CSharpApplicationException, $1->message);
+	}
+}
+
+
 
 //typemap for short maxlen strings
 //%typemap(in) (char *outputString, int maxlen) {


### PR DESCRIPTION
- [ ] I have reviewed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I agree to license my contributions under the same license as in this repository
- [ ] I have verified that the tests pass

### Description

- Handles helics functions that take an error argument by setting a C# exception -- seems to make the interface usable.
- Changes the C# namespace to gmlc, removing a duplicate `helics` from most function calls (gmlc.helics.helics.<function name> becomes gmlc.helics.<function name>)