### PR TITLE
Custom serialization

### DIFF
--- a/src/helics/common/timeRepresentation.hpp
+++ b/src/helics/common/timeRepresentation.hpp
@@ -21,9 +21,9 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <iosfwd>
 #include <limits>
 #include <type_traits>
-#include <iosfwd>
 #ifdef __cpp_lib_chrono
 #define CHRONO_CONSTEXPR constexpr
 #else
@@ -65,12 +65,12 @@ inline constexpr double pow2 (unsigned int exponent)
     return (exponent == 0) ? 1.0 : (2.0 * pow2 (exponent - 1));
 }
 /** generate a quick rounding operation as constexpr
-@details doesn't deal with very large numbers appropriately so 
+@details doesn't deal with very large numbers appropriately so
 assumes the numbers given are normal and within the type specified*/
 template <typename ITYPE>
-inline constexpr ITYPE quick_round(double val)
+inline constexpr ITYPE quick_round (double val)
 {
-    return static_cast<ITYPE>((val>=0.0)?(val+0.5):(val-0.5));
+    return static_cast<ITYPE> ((val >= 0.0) ? (val + 0.5) : (val - 0.5));
 }
 /** prototype class for representing time
 @details implements time as a count of 1/2^N seconds
@@ -316,7 +316,7 @@ class TimeRepresentation
 #endif
   public:
     /** default constructor*/
-    TimeRepresentation ()=default;
+    TimeRepresentation () = default;
 
   private:
 /** explicit means to generate a constexpr TimeRepresentation at time 0, negTime and maxTime and min time delta*/
@@ -350,13 +350,9 @@ class TimeRepresentation
 #ifdef _DEBUG
     /** normal time constructor from a double representation of seconds*/
     constexpr TimeRepresentation (double t) noexcept : timecode_ (Tconv::convert (t)), dtime_ (t) {}
-    TimeRepresentation(std::int64_t count, timeUnits units) noexcept
-        : timecode_(Tconv::fromCount(count, units)) {
-        DOUBLETIME
-    };
-    TimeRepresentation (
-            std::chrono::nanoseconds nsTime) noexcept
-        : timecode_ (Tconv::convert (nsTime))
+    TimeRepresentation (std::int64_t count, timeUnits units) noexcept
+        : timecode_ (Tconv::fromCount (count, units)){DOUBLETIME};
+    TimeRepresentation (std::chrono::nanoseconds nsTime) noexcept : timecode_ (Tconv::convert (nsTime))
     {
         DOUBLETIME
     }
@@ -411,7 +407,7 @@ class TimeRepresentation
         return *this;
     }
     /** direct conversion to chrono nanoseconds*/
-    std::chrono::nanoseconds to_ns() const
+    std::chrono::nanoseconds to_ns () const
     {
         return std::chrono::nanoseconds (Tconv::toCount (timecode_, timeUnits::ns));
     }

--- a/src/helics/core/ActionMessage.cpp
+++ b/src/helics/core/ActionMessage.cpp
@@ -301,7 +301,8 @@ int ActionMessage::fromByteArray (const char *data, size_t buffer_size)
             return static_cast<int> (res);
         }
     }
-    int sz = 256 * 256 * data[1] + 256 * data[2] + data[3];
+    int sz = 256 * 256 * (static_cast<uint8_t> (data[1])) + 256 * static_cast<uint8_t> (data[2]) +
+             static_cast<uint8_t> (data[3]);
     tsize += sz;
     if (buffer_size < tsize)
     {

--- a/src/helics/core/ActionMessage.cpp
+++ b/src/helics/core/ActionMessage.cpp
@@ -4,9 +4,9 @@ Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance
 All rights reserved. See LICENSE file and DISCLAIMER for more details.
 */
 #include "ActionMessage.hpp"
+#include "../common/fmt_format.h"
 #include "flagOperations.hpp"
 #include <complex>
-#include "../common/fmt_format.h"
 
 #include <algorithm>
 #include <cstring>
@@ -120,7 +120,7 @@ const std::string &ActionMessage::getString (int index) const
 
 void ActionMessage::setString (int index, const std::string &str)
 {
-    if (index >= 0)
+    if ((index >= 0) && (index < 256))
     {
         if (index >= static_cast<int> (stringData.size ()))
         {
@@ -128,107 +128,102 @@ void ActionMessage::setString (int index, const std::string &str)
         }
         stringData[index] = str;
     }
+    else
+    {
+        throw (std::invalid_argument ("index out of specified range (0-255)"));
+    }
 }
 
-
-/** load the data from an archive*/
-template <class Archive>
-void load(Archive &ar)
+/** check for little endian*/
+static inline std::uint8_t is_little_endian ()
 {
-	ar(messageAction, messageID);
-	identififier_base_type sid, sh, did, dh;
-	ar(sid, sh, did, dh);
-	source_id = global_federate_id_t(sid);
-	source_handle = interface_handle(sh);
-	dest_id = global_federate_id_t(did);
-	dest_handle = interface_handle(dh);
-
-	ar(counter, flags);
-	using timeBaseType = decltype ((actionTime.getBaseTimeCode()));
-	timeBaseType btc, Tebase, Tdeminbase, Tsobase;
-	ar(btc, Tebase, Tsobase, Tdeminbase, payload);
-
-	actionTime.setBaseTimeCode(btc);
-	Te.setBaseTimeCode(Tebase);
-	Tdemin.setBaseTimeCode(Tdeminbase);
-	Tso.setBaseTimeCode(Tsobase);
-	ar(stringData);
-}
+    static std::int32_t test = 1;
+    return *reinterpret_cast<std::int8_t *> (&test) == 1;
+};
 
 int ActionMessage::toByteArray (char *data, size_t buffer_size) const
 {
-	static const uint8_t littleEndian = is_little_endian();
-	
+    static const uint8_t littleEndian = is_little_endian ();
+
     if ((data == nullptr) || (buffer_size == 0))
     {
         return -1;
     }
-	char *dataStart = data;
-	//put the main string size in the first 4 bytes;
-	auto ssize = static_cast<uint32_t>(payload.size())&0x00FFFFFF;
-	*data = littleEndian;
-	data[1] = static_cast<uint8_t>(ssize >> 16);
-	data[2] = static_cast<uint8_t>((ssize >> 8) & 0xFF);
-	data[3] = static_cast<uint8_t>(ssize & 0xFF);
-	data+=sizeof(uint32_t);
-	*reinterpret_cast<action_message_def::action_t *>(data)=messageAction;
-	data += sizeof(action_message_def::action_t);
-	*reinterpret_cast<int32_t *>(data) = messageID;
-	data += sizeof(int32_t);
-	*reinterpret_cast<int32_t *>(data) = source_id.baseValue();
-	data += sizeof(int32_t);
-	*reinterpret_cast<int32_t *>(data) = source_handle.baseValue();
-	data += sizeof(int32_t);
-	*reinterpret_cast<int32_t *>(data) = dest_id.baseValue();
-	data += sizeof(int32_t);
-	*reinterpret_cast<int32_t *>(data) = dest_handle.baseValue();
-	data += sizeof(int32_t);
-	*reinterpret_cast<uint16_t *>(data) = counter;
-	data += sizeof(uint16_t);
-	*reinterpret_cast<uint16_t *>(data) = flags;
-	data += sizeof(uint16_t);
-	*reinterpret_cast<int64_t *>(data) = actionTime.getBaseTimeCode();
-	data += sizeof(int64_t);
-	
-	if (messageAction == CMD_TIME_REQUEST)
-	{
-		*reinterpret_cast<int64_t *>(data) = Te.getBaseTimeCode();
-		data += sizeof(int64_t);
-		*reinterpret_cast<int64_t *>(data) = Tdemin.getBaseTimeCode();
-		data += sizeof(int64_t);
-		*reinterpret_cast<int64_t *>(data) = Tso.getBaseTimeCode();
-		data += sizeof(int64_t);
-	}
-	if (ssize > 0)
-	{
-		std::memcpy(data, payload.data(), ssize);
-		data += ssize;
-	}
-	
-	if (stringData.empty())
-	{
-		*data = 0;
-		++data;
-	}
-	else
-	{
-		for (auto &str:stringData)
-		{
-			*reinterpret_cast<uint32_t *>(data) = static_cast<uint32_t>(str.size());
-			data += sizeof(uint32_t);
-			memcpy(data, str.data(), str.size());
-			data += str.size();
-		}
-	}
-	return static_cast<int>(data - dataStart);
+    if (buffer_size < serializedByteCount ())
+    {
+        return -1;
+    }
+    char *dataStart = data;
+    // put the main string size in the first 4 bytes;
+    auto ssize = static_cast<uint32_t> (payload.size ()) & 0x00FFFFFF;
+    *data = littleEndian;
+    data[1] = static_cast<uint8_t> (ssize >> 16);
+    data[2] = static_cast<uint8_t> ((ssize >> 8) & 0xFF);
+    data[3] = static_cast<uint8_t> (ssize & 0xFF);
+    data += sizeof (uint32_t);
+    *reinterpret_cast<action_message_def::action_t *> (data) = messageAction;
+    data += sizeof (action_message_def::action_t);
+    *reinterpret_cast<int32_t *> (data) = messageID;
+    data += sizeof (int32_t);
+    *reinterpret_cast<int32_t *> (data) = source_id.baseValue ();
+    data += sizeof (int32_t);
+    *reinterpret_cast<int32_t *> (data) = source_handle.baseValue ();
+    data += sizeof (int32_t);
+    *reinterpret_cast<int32_t *> (data) = dest_id.baseValue ();
+    data += sizeof (int32_t);
+    *reinterpret_cast<int32_t *> (data) = dest_handle.baseValue ();
+    data += sizeof (int32_t);
+    *reinterpret_cast<uint16_t *> (data) = counter;
+    data += sizeof (uint16_t);
+    *reinterpret_cast<uint16_t *> (data) = flags;
+    data += sizeof (uint16_t);
+    *reinterpret_cast<int32_t *> (data) = sequenceID;
+    data += sizeof (int32_t);
+    *reinterpret_cast<int64_t *> (data) = actionTime.getBaseTimeCode ();
+    data += sizeof (int64_t);
+
+    if (messageAction == CMD_TIME_REQUEST)
+    {
+        *reinterpret_cast<int64_t *> (data) = Te.getBaseTimeCode ();
+        data += sizeof (int64_t);
+        *reinterpret_cast<int64_t *> (data) = Tdemin.getBaseTimeCode ();
+        data += sizeof (int64_t);
+        *reinterpret_cast<int64_t *> (data) = Tso.getBaseTimeCode ();
+        data += sizeof (int64_t);
+    }
+    if (ssize > 0)
+    {
+        std::memcpy (data, payload.data (), ssize);
+        data += ssize;
+    }
+
+    if (stringData.empty ())
+    {
+        *data = 0;
+        ++data;
+    }
+    else
+    {
+        *data = static_cast<uint8_t> (stringData.size ());
+        ++data;
+        for (auto &str : stringData)
+        {
+            *reinterpret_cast<uint32_t *> (data) = static_cast<uint32_t> (str.size ());
+            data += sizeof (uint32_t);
+            memcpy (data, str.data (), str.size ());
+            data += str.size ();
+        }
+    }
+    auto actSize = static_cast<int> (data - dataStart);
+    return actSize;
 }
 
 std::string ActionMessage::to_string () const
 {
     std::string data;
-	auto sz = serializedByteCount();
-	data.resize(sz+1);
-	toByteArray(&(data[0]), sz + 1);
+    auto sz = serializedByteCount ();
+    data.resize (sz);
+    toByteArray (&(data[0]), sz);
     return data;
 }
 
@@ -239,11 +234,17 @@ constexpr auto TAIL_CHAR2 = '\xFC';
 std::string ActionMessage::packetize () const
 {
     std::string data;
-	auto sz = serializedByteCount();
-	data.resize(sz + 4);
-	toByteArray(&(data[4]), sz + 1);
+    packetize (data);
+    return data;
+}
 
-    data[0]= LEADING_CHAR;
+void ActionMessage::packetize (std::string &data) const
+{
+    auto sz = serializedByteCount ();
+    data.resize (sz + 4);
+    toByteArray (&(data[4]), sz);
+
+    data[0] = LEADING_CHAR;
     // now generate a length header
     auto dsz = static_cast<uint32_t> (data.size ());
     data[1] = static_cast<char> (((dsz >> 16) & 0xFF));
@@ -251,148 +252,176 @@ std::string ActionMessage::packetize () const
     data[3] = static_cast<char> (dsz & 0xFF);
     data.push_back (TAIL_CHAR1);
     data.push_back (TAIL_CHAR2);
-    return data;
 }
 
 std::vector<char> ActionMessage::to_vector () const
 {
     std::vector<char> data;
-	auto sz = serializedByteCount();
-	data.resize(sz + 1);
-	toByteArray(data.data(), sz + 1);
-	return data;
+    auto sz = serializedByteCount ();
+    data.resize (sz);
+    toByteArray (data.data (), sz);
+    return data;
 }
 
 void ActionMessage::to_vector (std::vector<char> &data) const
 {
-	auto sz = serializedByteCount();
-	data.resize(sz + 1);
-	toByteArray(data.data(), sz + 1);
+    auto sz = serializedByteCount ();
+    data.resize (sz);
+    toByteArray (data.data (), sz);
 }
 
 void ActionMessage::to_string (std::string &data) const
 {
-	auto sz = serializedByteCount();
-	data.resize(sz + 1);
-	toByteArray(&(data[0]), sz + 1);
+    auto sz = serializedByteCount ();
+    data.resize (sz);
+    toByteArray (&(data[0]), sz);
 }
 
 template <std::size_t DataSize>
-inline void swap_bytes(std::uint8_t * data)
+inline void swap_bytes (std::uint8_t *data)
 {
-	for (std::size_t i = 0, end = DataSize / 2; i < end; ++i)
-		std::swap(data[i], data[DataSize - i - 1]);
+    for (std::size_t i = 0, end = DataSize / 2; i < end; ++i)
+        std::swap (data[i], data[DataSize - i - 1]);
 }
-
 
 int ActionMessage::fromByteArray (const char *data, size_t buffer_size)
 {
-	static const uint8_t littleEndian = is_little_endian();
-
+    int tsize = 45;
+    static const uint8_t littleEndian = is_little_endian ();
+    if (buffer_size < tsize)
+    {
+        messageAction = CMD_INVALID;
+        return (0);
+    }
     if (data[0] == LEADING_CHAR)
     {
         auto res = depacketize (data, buffer_size);
         if (res > 0)
         {
-            return static_cast<int>(res);
+            return static_cast<int> (res);
         }
     }
-	int sz = 256*256*data[1] + 256 * data[2] + data[3];
-	bool swap = (data[0] != littleEndian);
-	data += sizeof(uint32_t);
-	messageAction=*reinterpret_cast<const action_message_def::action_t *>(data);
-	if (swap)
-	{
-		swap_bytes<4>(reinterpret_cast<std::uint8_t *>(&messageAction));
-	}
-	data += sizeof(action_message_def::action_t);
-	messageID=*reinterpret_cast<const int32_t *>(data);
-	data += sizeof(int32_t);
-	source_id=global_federate_id_t(*reinterpret_cast<const int32_t *>(data));
-	data += sizeof(int32_t);
-	source_handle=interface_handle(*reinterpret_cast<const int32_t *>(data));
-	data += sizeof(int32_t);
-	dest_id=global_federate_id_t(*reinterpret_cast<const int32_t *>(data));
-	data += sizeof(int32_t);
-	dest_handle=interface_handle(*reinterpret_cast<const int32_t *>(data));
-	data += sizeof(int32_t);
-	counter=*reinterpret_cast<const uint16_t *>(data);
-	data += sizeof(uint16_t);
-	flags=*reinterpret_cast<const uint16_t *>(data);
-	data += sizeof(uint16_t);
-	actionTime.setBaseTimeCode(*reinterpret_cast<const int64_t *>(data));
-	data += sizeof(int64_t);
+    int sz = 256 * 256 * data[1] + 256 * data[2] + data[3];
+    tsize += sz;
+    if (buffer_size < tsize)
+    {
+        messageAction = CMD_INVALID;
+        return (0);
+    }
+    bool swap = (data[0] != littleEndian);
+    data += sizeof (uint32_t);
+    messageAction = *reinterpret_cast<const action_message_def::action_t *> (data);
+    if (swap)
+    {
+        swap_bytes<4> (reinterpret_cast<std::uint8_t *> (&messageAction));
+    }
+    data += sizeof (action_message_def::action_t);
+    messageID = *reinterpret_cast<const int32_t *> (data);
+    data += sizeof (int32_t);
+    source_id = global_federate_id_t (*reinterpret_cast<const int32_t *> (data));
+    data += sizeof (int32_t);
+    source_handle = interface_handle (*reinterpret_cast<const int32_t *> (data));
+    data += sizeof (int32_t);
+    dest_id = global_federate_id_t (*reinterpret_cast<const int32_t *> (data));
+    data += sizeof (int32_t);
+    dest_handle = interface_handle (*reinterpret_cast<const int32_t *> (data));
+    data += sizeof (int32_t);
+    counter = *reinterpret_cast<const uint16_t *> (data);
+    data += sizeof (uint16_t);
+    flags = *reinterpret_cast<const uint16_t *> (data);
+    data += sizeof (uint16_t);
+    sequenceID = *reinterpret_cast<const uint32_t *> (data);
+    data += sizeof (uint32_t);
+    actionTime.setBaseTimeCode (*reinterpret_cast<const int64_t *> (data));
+    data += sizeof (int64_t);
 
-	if (messageAction == CMD_TIME_REQUEST)
-	{
-		Te.setBaseTimeCode(*reinterpret_cast<const int64_t *>(data));
-		data += sizeof(int64_t);
-		Tdemin.setBaseTimeCode(*reinterpret_cast<const int64_t *>(data));
-		data += sizeof(int64_t);
-		Tso.setBaseTimeCode(*reinterpret_cast<const int64_t *>(data));
-		data += sizeof(int64_t);
-	}
-	else
-	{
-		Te = timeZero;
-		Tdemin = timeZero;
-		Tso = timeZero;
-	}
-	if (sz > 0)
-	{
-		payload.assign(data, sz);
-		data += sz;
-	}
-	int stringCount = *data;
-	++data;
-	if (stringCount != 0)
-	{
-		stringData.resize(stringCount);
-		
-		for (int ii = 0; ii<stringCount; ++ii)
-		{
-			auto ssize = *reinterpret_cast<const uint32_t *>(data);
-			data += 4;
-			if (swap)
-			{
-				swap_bytes<4>(reinterpret_cast<std::uint8_t *>(&ssize));
-			}
-			stringData[ii].assign(data, ssize);
-			data += ssize;
-		}
-	}
-	else
-	{
-		stringData.clear();
-		
-	}
-	
-	if (swap)
-	{
-		swap_bytes<4>(reinterpret_cast<std::uint8_t *>(&messageID));
-		swap_bytes<4>(reinterpret_cast<std::uint8_t *>(&source_id));
-		swap_bytes<4>(reinterpret_cast<std::uint8_t *>(&source_handle));
-		swap_bytes<4>(reinterpret_cast<std::uint8_t *>(&dest_id));
-		swap_bytes<4>(reinterpret_cast<std::uint8_t *>(&dest_handle));
-		swap_bytes<2>(reinterpret_cast<std::uint8_t *>(&counter));
-		swap_bytes<2>(reinterpret_cast<std::uint8_t *>(&flags));
-		auto timecode = actionTime.getBaseTimeCode();
-		swap_bytes<8>(reinterpret_cast<std::uint8_t *>(&timecode));
-		actionTime.setBaseTimeCode(timecode);
-		if (messageAction == CMD_TIME_REQUEST)
-		{
-			timecode = Te.getBaseTimeCode();
-			swap_bytes<8>(reinterpret_cast<std::uint8_t *>(&timecode));
-			Te.setBaseTimeCode(timecode);
-			timecode = Tdemin.getBaseTimeCode();
-			swap_bytes<8>(reinterpret_cast<std::uint8_t *>(&timecode));
-			Tdemin.setBaseTimeCode(timecode);
-			timecode = Tso.getBaseTimeCode();
-			swap_bytes<8>(reinterpret_cast<std::uint8_t *>(&timecode));
-			Tso.setBaseTimeCode(timecode);
-		}
-	}
-	return serializedByteCount();
+    if (messageAction == CMD_TIME_REQUEST)
+    {
+        tsize += 24;
+        if (buffer_size < tsize)
+        {
+            messageAction = CMD_INVALID;
+            return (0);
+        }
+        Te.setBaseTimeCode (*reinterpret_cast<const int64_t *> (data));
+        data += sizeof (int64_t);
+        Tdemin.setBaseTimeCode (*reinterpret_cast<const int64_t *> (data));
+        data += sizeof (int64_t);
+        Tso.setBaseTimeCode (*reinterpret_cast<const int64_t *> (data));
+        data += sizeof (int64_t);
+    }
+    else
+    {
+        Te = timeZero;
+        Tdemin = timeZero;
+        Tso = timeZero;
+    }
+    if (sz > 0)
+    {
+        payload.assign (data, sz);
+        data += sz;
+    }
+    int stringCount = *data;
+    ++data;
+    if (stringCount != 0)
+    {
+        stringData.resize (stringCount);
+        tsize += 4 * stringCount;
+        if (buffer_size < tsize)
+        {
+            messageAction = CMD_INVALID;
+            return (0);
+        }
+
+        for (int ii = 0; ii < stringCount; ++ii)
+        {
+            auto ssize = *reinterpret_cast<const uint32_t *> (data);
+            data += 4;
+            if (swap)
+            {
+                swap_bytes<4> (reinterpret_cast<std::uint8_t *> (&ssize));
+            }
+            tsize += ssize;
+            if (buffer_size < tsize)
+            {
+                messageAction = CMD_INVALID;
+                return (0);
+            }
+            stringData[ii].assign (data, ssize);
+            data += ssize;
+        }
+    }
+    else
+    {
+        stringData.clear ();
+    }
+
+    if (swap)
+    {
+        swap_bytes<4> (reinterpret_cast<std::uint8_t *> (&messageID));
+        swap_bytes<4> (reinterpret_cast<std::uint8_t *> (&source_id));
+        swap_bytes<4> (reinterpret_cast<std::uint8_t *> (&source_handle));
+        swap_bytes<4> (reinterpret_cast<std::uint8_t *> (&dest_id));
+        swap_bytes<4> (reinterpret_cast<std::uint8_t *> (&dest_handle));
+        swap_bytes<2> (reinterpret_cast<std::uint8_t *> (&counter));
+        swap_bytes<2> (reinterpret_cast<std::uint8_t *> (&flags));
+        auto timecode = actionTime.getBaseTimeCode ();
+        swap_bytes<8> (reinterpret_cast<std::uint8_t *> (&timecode));
+        actionTime.setBaseTimeCode (timecode);
+        if (messageAction == CMD_TIME_REQUEST)
+        {
+            timecode = Te.getBaseTimeCode ();
+            swap_bytes<8> (reinterpret_cast<std::uint8_t *> (&timecode));
+            Te.setBaseTimeCode (timecode);
+            timecode = Tdemin.getBaseTimeCode ();
+            swap_bytes<8> (reinterpret_cast<std::uint8_t *> (&timecode));
+            Tdemin.setBaseTimeCode (timecode);
+            timecode = Tso.getBaseTimeCode ();
+            swap_bytes<8> (reinterpret_cast<std::uint8_t *> (&timecode));
+            Tso.setBaseTimeCode (timecode);
+        }
+    }
+    return tsize;
 }
 
 size_t ActionMessage::depacketize (const char *data, size_t buffer_size)
@@ -422,10 +451,9 @@ size_t ActionMessage::depacketize (const char *data, size_t buffer_size)
     {
         return 0;
     }
-   
-	int bytesUsed=fromByteArray(data + 4, message_size - 4);
-	return (bytesUsed > 0) ? message_size + 2 : 0;
-	
+
+    int bytesUsed = fromByteArray (data + 4, message_size - 4);
+    return (bytesUsed > 0) ? message_size + 2 : 0;
 }
 
 void ActionMessage::from_string (const std::string &data) { fromByteArray (data.data (), data.size ()); }
@@ -507,7 +535,7 @@ static constexpr std::pair<action_message_def::action_t, const char *> actionStr
   {action_message_def::action_t::cmd_priority_disconnect, "priority_disconnect"},
   {action_message_def::action_t::cmd_disconnect, "disconnect"},
   {action_message_def::action_t::cmd_disconnect_name, "disconnect by name"},
-{ action_message_def::action_t::cmd_user_disconnect, "disconnect from user" },
+  {action_message_def::action_t::cmd_user_disconnect, "disconnect from user"},
   {action_message_def::action_t::cmd_fed_ack, "fed_ack"},
 
   {action_message_def::action_t::cmd_broker_ack, "broker_ack"},
@@ -596,7 +624,7 @@ const char *actionMessageType (action_message_def::action_t action)
     if (res != pptr + actEnd)
     {
         return res->second;
-    }  
+    }
     return static_cast<const char *> (unknownStr);
 }
 
@@ -605,8 +633,7 @@ static constexpr std::pair<int, const char *> errorStrings[] = {
   {-5, "lost connection with server"},
   {5, "already in initialization mode"},
   {6, "duplicate federate name detected"},
-{ 7, "duplicate broker name detected" }
-};
+  {7, "duplicate broker name detected"}};
 
 using errorPair = std::pair<int, const char *>;
 static constexpr size_t errEnd = sizeof (errorStrings) / sizeof (errorPair);
@@ -627,11 +654,11 @@ const char *commandErrorString (int errorcode)
 std::string prettyPrintString (const ActionMessage &command)
 {
     std::string ret (actionMessageType (command.action ()));
-	if (ret == unknownStr)
-	{
+    if (ret == unknownStr)
+    {
         ret += " " + std::to_string (static_cast<int> (command.action ()));
         return ret;
-	}
+    }
     switch (command.action ())
     {
     case CMD_REG_FED:

--- a/src/helics/core/ActionMessage.cpp
+++ b/src/helics/core/ActionMessage.cpp
@@ -5,14 +5,11 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 */
 #include "ActionMessage.hpp"
 #include "flagOperations.hpp"
-#include <cereal/archives/portable_binary.hpp>
 #include <complex>
-//#include <cereal/archives/binary.hpp>
 #include "../common/fmt_format.h"
-#include <boost/iostreams/device/back_inserter.hpp>
-#include <boost/iostreams/stream.hpp>
 
 #include <algorithm>
+#include <cstring>
 
 namespace helics
 {
@@ -132,42 +129,106 @@ void ActionMessage::setString (int index, const std::string &str)
         stringData[index] = str;
     }
 }
-using archiver = cereal::PortableBinaryOutputArchive;
 
-using retriever = cereal::PortableBinaryInputArchive;
+
+/** load the data from an archive*/
+template <class Archive>
+void load(Archive &ar)
+{
+	ar(messageAction, messageID);
+	identififier_base_type sid, sh, did, dh;
+	ar(sid, sh, did, dh);
+	source_id = global_federate_id_t(sid);
+	source_handle = interface_handle(sh);
+	dest_id = global_federate_id_t(did);
+	dest_handle = interface_handle(dh);
+
+	ar(counter, flags);
+	using timeBaseType = decltype ((actionTime.getBaseTimeCode()));
+	timeBaseType btc, Tebase, Tdeminbase, Tsobase;
+	ar(btc, Tebase, Tsobase, Tdeminbase, payload);
+
+	actionTime.setBaseTimeCode(btc);
+	Te.setBaseTimeCode(Tebase);
+	Tdemin.setBaseTimeCode(Tdeminbase);
+	Tso.setBaseTimeCode(Tsobase);
+	ar(stringData);
+}
 
 int ActionMessage::toByteArray (char *data, size_t buffer_size) const
 {
+	static const uint8_t littleEndian = is_little_endian();
+	
     if ((data == nullptr) || (buffer_size == 0))
     {
         return -1;
     }
-    boost::iostreams::basic_array_sink<char> sr (data, buffer_size);
-    boost::iostreams::stream<boost::iostreams::basic_array_sink<char>> s (sr);
-
-    archiver oa (s);
-    try
-    {
-        save (oa);
-        return static_cast<int> (boost::iostreams::seek (s, 0, std::ios_base::cur));
-    }
-    catch (const std::ios_base::failure &)
-    {
-        return -1;
-    }
+	char *dataStart = data;
+	//put the main string size in the first 4 bytes;
+	auto ssize = static_cast<uint32_t>(payload.size())&0x00FFFFFF;
+	*data = littleEndian;
+	data[1] = static_cast<uint8_t>(ssize >> 16);
+	data[2] = static_cast<uint8_t>((ssize >> 8) & 0xFF);
+	data[3] = static_cast<uint8_t>(ssize & 0xFF);
+	data+=sizeof(uint32_t);
+	*reinterpret_cast<action_message_def::action_t *>(data)=messageAction;
+	data += sizeof(action_message_def::action_t);
+	*reinterpret_cast<int32_t *>(data) = messageID;
+	data += sizeof(int32_t);
+	*reinterpret_cast<int32_t *>(data) = source_id.baseValue();
+	data += sizeof(int32_t);
+	*reinterpret_cast<int32_t *>(data) = source_handle.baseValue();
+	data += sizeof(int32_t);
+	*reinterpret_cast<int32_t *>(data) = dest_id.baseValue();
+	data += sizeof(int32_t);
+	*reinterpret_cast<int32_t *>(data) = dest_handle.baseValue();
+	data += sizeof(int32_t);
+	*reinterpret_cast<uint16_t *>(data) = counter;
+	data += sizeof(uint16_t);
+	*reinterpret_cast<uint16_t *>(data) = flags;
+	data += sizeof(uint16_t);
+	*reinterpret_cast<int64_t *>(data) = actionTime.getBaseTimeCode();
+	data += sizeof(int64_t);
+	
+	if (messageAction == CMD_TIME_REQUEST)
+	{
+		*reinterpret_cast<int64_t *>(data) = Te.getBaseTimeCode();
+		data += sizeof(int64_t);
+		*reinterpret_cast<int64_t *>(data) = Tdemin.getBaseTimeCode();
+		data += sizeof(int64_t);
+		*reinterpret_cast<int64_t *>(data) = Tso.getBaseTimeCode();
+		data += sizeof(int64_t);
+	}
+	if (ssize > 0)
+	{
+		std::memcpy(data, payload.data(), ssize);
+		data += ssize;
+	}
+	
+	if (stringData.empty())
+	{
+		*data = 0;
+		++data;
+	}
+	else
+	{
+		for (auto &str:stringData)
+		{
+			*reinterpret_cast<uint32_t *>(data) = static_cast<uint32_t>(str.size());
+			data += sizeof(uint32_t);
+			memcpy(data, str.data(), str.size());
+			data += str.size();
+		}
+	}
+	return static_cast<int>(data - dataStart);
 }
 
 std::string ActionMessage::to_string () const
 {
     std::string data;
-    boost::iostreams::back_insert_device<std::string> inserter (data);
-    boost::iostreams::stream<boost::iostreams::back_insert_device<std::string>> s (inserter);
-    archiver oa (s);
-
-    save (oa);
-
-    // don't forget to flush the stream to finish writing into the buffer
-    s.flush ();
+	auto sz = serializedByteCount();
+	data.resize(sz+1);
+	toByteArray(&(data[0]), sz + 1);
     return data;
 }
 
@@ -178,21 +239,16 @@ constexpr auto TAIL_CHAR2 = '\xFC';
 std::string ActionMessage::packetize () const
 {
     std::string data;
-    data.push_back (LEADING_CHAR);
-    data.resize (4);
-    boost::iostreams::back_insert_device<std::string> inserter (data);
-    boost::iostreams::stream<boost::iostreams::back_insert_device<std::string>> s (inserter);
-    archiver oa (s);
+	auto sz = serializedByteCount();
+	data.resize(sz + 4);
+	toByteArray(&(data[4]), sz + 1);
 
-    save (oa);
-
-    // don't forget to flush the stream to finish writing into the buffer
-    s.flush ();
+    data[0]= LEADING_CHAR;
     // now generate a length header
-    auto sz = static_cast<uint32_t> (data.size ());
-    data[1] = static_cast<char> (((sz >> 16) & 0xFF));
-    data[2] = static_cast<char> (((sz >> 8) & 0xFF));
-    data[3] = static_cast<char> (sz & 0xFF);
+    auto dsz = static_cast<uint32_t> (data.size ());
+    data[1] = static_cast<char> (((dsz >> 16) & 0xFF));
+    data[2] = static_cast<char> (((dsz >> 8) & 0xFF));
+    data[3] = static_cast<char> (dsz & 0xFF);
     data.push_back (TAIL_CHAR1);
     data.push_back (TAIL_CHAR2);
     return data;
@@ -201,65 +257,142 @@ std::string ActionMessage::packetize () const
 std::vector<char> ActionMessage::to_vector () const
 {
     std::vector<char> data;
-    boost::iostreams::back_insert_device<std::vector<char>> inserter (data);
-    boost::iostreams::stream<boost::iostreams::back_insert_device<std::vector<char>>> s (inserter);
-    archiver oa (s);
-
-    save (oa);
-
-    // don't forget to flush the stream to finish writing into the buffer
-    s.flush ();
-    return data;
+	auto sz = serializedByteCount();
+	data.resize(sz + 1);
+	toByteArray(data.data(), sz + 1);
+	return data;
 }
 
 void ActionMessage::to_vector (std::vector<char> &data) const
 {
-    data.clear ();
-    boost::iostreams::back_insert_device<std::vector<char>> inserter (data);
-    boost::iostreams::stream<boost::iostreams::back_insert_device<std::vector<char>>> s (inserter);
-    archiver oa (s);
-
-    save (oa);
-
-    // don't forget to flush the stream to finish writing into the buffer
-    s.flush ();
+	auto sz = serializedByteCount();
+	data.resize(sz + 1);
+	toByteArray(data.data(), sz + 1);
 }
 
 void ActionMessage::to_string (std::string &data) const
 {
-    data.clear ();
-
-    boost::iostreams::back_insert_device<std::string> inserter (data);
-    boost::iostreams::stream<boost::iostreams::back_insert_device<std::string>> s (inserter);
-    archiver oa (s);
-
-    save (oa);
-
-    // don't forget to flush the stream to finish writing into the buffer
-    s.flush ();
+	auto sz = serializedByteCount();
+	data.resize(sz + 1);
+	toByteArray(&(data[0]), sz + 1);
 }
 
-void ActionMessage::fromByteArray (const char *data, size_t buffer_size)
+template <std::size_t DataSize>
+inline void swap_bytes(std::uint8_t * data)
 {
+	for (std::size_t i = 0, end = DataSize / 2; i < end; ++i)
+		std::swap(data[i], data[DataSize - i - 1]);
+}
+
+
+int ActionMessage::fromByteArray (const char *data, size_t buffer_size)
+{
+	static const uint8_t littleEndian = is_little_endian();
+
     if (data[0] == LEADING_CHAR)
     {
         auto res = depacketize (data, buffer_size);
         if (res > 0)
         {
-            return;
+            return static_cast<int>(res);
         }
     }
-    boost::iostreams::basic_array_source<char> device (data, buffer_size);
-    boost::iostreams::stream<boost::iostreams::basic_array_source<char>> s (device);
-    retriever ia (s);
-    try
-    {
-        load (ia);
-    }
-    catch (const cereal::Exception &ce)
-    {
-        messageAction = CMD_INVALID;
-    }
+	int sz = 256*256*data[1] + 256 * data[2] + data[3];
+	bool swap = (data[0] != littleEndian);
+	data += sizeof(uint32_t);
+	messageAction=*reinterpret_cast<const action_message_def::action_t *>(data);
+	if (swap)
+	{
+		swap_bytes<4>(reinterpret_cast<std::uint8_t *>(&messageAction));
+	}
+	data += sizeof(action_message_def::action_t);
+	messageID=*reinterpret_cast<const int32_t *>(data);
+	data += sizeof(int32_t);
+	source_id=global_federate_id_t(*reinterpret_cast<const int32_t *>(data));
+	data += sizeof(int32_t);
+	source_handle=interface_handle(*reinterpret_cast<const int32_t *>(data));
+	data += sizeof(int32_t);
+	dest_id=global_federate_id_t(*reinterpret_cast<const int32_t *>(data));
+	data += sizeof(int32_t);
+	dest_handle=interface_handle(*reinterpret_cast<const int32_t *>(data));
+	data += sizeof(int32_t);
+	counter=*reinterpret_cast<const uint16_t *>(data);
+	data += sizeof(uint16_t);
+	flags=*reinterpret_cast<const uint16_t *>(data);
+	data += sizeof(uint16_t);
+	actionTime.setBaseTimeCode(*reinterpret_cast<const int64_t *>(data));
+	data += sizeof(int64_t);
+
+	if (messageAction == CMD_TIME_REQUEST)
+	{
+		Te.setBaseTimeCode(*reinterpret_cast<const int64_t *>(data));
+		data += sizeof(int64_t);
+		Tdemin.setBaseTimeCode(*reinterpret_cast<const int64_t *>(data));
+		data += sizeof(int64_t);
+		Tso.setBaseTimeCode(*reinterpret_cast<const int64_t *>(data));
+		data += sizeof(int64_t);
+	}
+	else
+	{
+		Te = timeZero;
+		Tdemin = timeZero;
+		Tso = timeZero;
+	}
+	if (sz > 0)
+	{
+		payload.assign(data, sz);
+		data += sz;
+	}
+	int stringCount = *data;
+	++data;
+	if (stringCount != 0)
+	{
+		stringData.resize(stringCount);
+		
+		for (int ii = 0; ii<stringCount; ++ii)
+		{
+			auto ssize = *reinterpret_cast<const uint32_t *>(data);
+			data += 4;
+			if (swap)
+			{
+				swap_bytes<4>(reinterpret_cast<std::uint8_t *>(&ssize));
+			}
+			stringData[ii].assign(data, ssize);
+			data += ssize;
+		}
+	}
+	else
+	{
+		stringData.clear();
+		
+	}
+	
+	if (swap)
+	{
+		swap_bytes<4>(reinterpret_cast<std::uint8_t *>(&messageID));
+		swap_bytes<4>(reinterpret_cast<std::uint8_t *>(&source_id));
+		swap_bytes<4>(reinterpret_cast<std::uint8_t *>(&source_handle));
+		swap_bytes<4>(reinterpret_cast<std::uint8_t *>(&dest_id));
+		swap_bytes<4>(reinterpret_cast<std::uint8_t *>(&dest_handle));
+		swap_bytes<2>(reinterpret_cast<std::uint8_t *>(&counter));
+		swap_bytes<2>(reinterpret_cast<std::uint8_t *>(&flags));
+		auto timecode = actionTime.getBaseTimeCode();
+		swap_bytes<8>(reinterpret_cast<std::uint8_t *>(&timecode));
+		actionTime.setBaseTimeCode(timecode);
+		if (messageAction == CMD_TIME_REQUEST)
+		{
+			timecode = Te.getBaseTimeCode();
+			swap_bytes<8>(reinterpret_cast<std::uint8_t *>(&timecode));
+			Te.setBaseTimeCode(timecode);
+			timecode = Tdemin.getBaseTimeCode();
+			swap_bytes<8>(reinterpret_cast<std::uint8_t *>(&timecode));
+			Tdemin.setBaseTimeCode(timecode);
+			timecode = Tso.getBaseTimeCode();
+			swap_bytes<8>(reinterpret_cast<std::uint8_t *>(&timecode));
+			Tso.setBaseTimeCode(timecode);
+		}
+	}
+	return serializedByteCount();
 }
 
 size_t ActionMessage::depacketize (const char *data, size_t buffer_size)
@@ -289,19 +422,10 @@ size_t ActionMessage::depacketize (const char *data, size_t buffer_size)
     {
         return 0;
     }
-    boost::iostreams::basic_array_source<char> device (data + 4, message_size);
-    boost::iostreams::stream<boost::iostreams::basic_array_source<char>> s (device);
-    retriever ia (s);
-    try
-    {
-        load (ia);
-        return message_size + 2;
-    }
-    catch (const cereal::Exception &ce)
-    {
-        messageAction = CMD_INVALID;
-        return 0;
-    }
+   
+	int bytesUsed=fromByteArray(data + 4, message_size - 4);
+	return (bytesUsed > 0) ? message_size + 2 : 0;
+	
 }
 
 void ActionMessage::from_string (const std::string &data) { fromByteArray (data.data (), data.size ()); }

--- a/src/helics/core/ActionMessage.hpp
+++ b/src/helics/core/ActionMessage.hpp
@@ -177,7 +177,7 @@ class ActionMessage
     @param[in] buffer_size-- the size of the buffer
     @return the size of the buffer actually used
     */
-    int toByteArray (char *data, size_t buffer_size) const;
+    int toByteArray (char *data, int buffer_size) const;
     /** convert to a string using a reference*/
     void to_string (std::string &data) const;
     /** convert to a byte string*/
@@ -191,11 +191,11 @@ class ActionMessage
     /** convert a command to a byte vector*/
     std::vector<char> to_vector () const;
     /** generate a command from a raw data stream*/
-    int fromByteArray (const char *data, size_t buffer_size);
+    int fromByteArray (const char *data, int buffer_size);
     /** load a command from a packetized stream /ref packetize
     @return the number of bytes used
     */
-    size_t depacketize (const char *data, size_t buffer_size);
+    int depacketize (const char *data, int buffer_size);
     /** read a command from a string*/
     void from_string (const std::string &data);
     /** read a command from a char vector*/

--- a/src/helics/core/CommonCore.hpp
+++ b/src/helics/core/CommonCore.hpp
@@ -26,6 +26,7 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #include <cstdint>
 #include <thread>
 #include <utility>
+#include <set>
 
 namespace helics
 {

--- a/src/helics/core/CommsInterface.cpp
+++ b/src/helics/core/CommsInterface.cpp
@@ -5,6 +5,7 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 */
 #include "CommsInterface.hpp"
 #include "NetworkBrokerData.hpp"
+#include <iostream>
 
 namespace helics
 {

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -21,6 +21,7 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #include "loggingHelper.hpp"
 #include "queryHelpers.hpp"
 #include <fstream>
+#include <iostream>
 
 namespace helics
 {

--- a/src/helics/core/CoreFactory.cpp
+++ b/src/helics/core/CoreFactory.cpp
@@ -17,8 +17,8 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 
 #include "../common/delayedDestructor.hpp"
 #include "../common/searchableObjectHolder.hpp"
-#include "test/TestCore.h"
 #include "ipc/IpcCore.h"
+#include "test/TestCore.h"
 #include "udp/UdpCore.h"
 
 #ifndef DISABLE_TCP_CORE
@@ -26,6 +26,7 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #endif
 
 #include <cassert>
+#include <cstring>
 
 namespace helics
 {
@@ -119,16 +120,16 @@ std::shared_ptr<Core> makeCore (core_type type, const std::string &name)
         break;
     case core_type::TCP_SS:
 #ifndef DISABLE_TCP_CORE
-        if (name.empty())
+        if (name.empty ())
         {
-            core = std::make_shared<tcp::TcpCoreSS>();
+            core = std::make_shared<tcp::TcpCoreSS> ();
         }
         else
         {
-            core = std::make_shared<tcp::TcpCoreSS>(name);
+            core = std::make_shared<tcp::TcpCoreSS> (name);
         }
 #else
-        throw (HelicsException("TCP single socket core is not available"));
+        throw (HelicsException ("TCP single socket core is not available"));
 #endif
         break;
     default:
@@ -141,7 +142,7 @@ namespace CoreFactory
 {
 std::shared_ptr<Core> create (core_type type, const std::string &initializationString)
 {
-    auto core = makeCore (type, std::string());
+    auto core = makeCore (type, std::string ());
     core->initialize (initializationString);
     registerCore (core);
 

--- a/src/helics/core/MessageTimer.cpp
+++ b/src/helics/core/MessageTimer.cpp
@@ -5,6 +5,7 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 */
 
 #include "MessageTimer.hpp"
+#include <iostream>
 
 namespace helics
 {

--- a/src/helics/core/NetworkBroker_impl.hpp
+++ b/src/helics/core/NetworkBroker_impl.hpp
@@ -7,6 +7,8 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 
 #include "../core/core-types.hpp"
 #include "NetworkBroker.hpp"
+#include <iostream>
+
 namespace helics
 {
 constexpr const char *tstr[] = {"default", "ZeroMQ", "MPI",   "TEST",   "IPC",      "interprocess",

--- a/src/helics/core/NetworkCommsInterface.hpp
+++ b/src/helics/core/NetworkCommsInterface.hpp
@@ -7,7 +7,8 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 
 #include "CommsInterface.hpp"
 #include "helics/helics-config.h"
-
+#include <map>
+#include <set>
 
 namespace helics
 {

--- a/src/helics/core/TimeCoordinator.hpp
+++ b/src/helics/core/TimeCoordinator.hpp
@@ -11,6 +11,7 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #include "TimeDependencies.hpp"
 #include <atomic>
 #include <functional>
+#include <deque>
 
 namespace helics
 {

--- a/src/helics/core/mpi/MpiBroker.cpp
+++ b/src/helics/core/mpi/MpiBroker.cpp
@@ -4,9 +4,9 @@ Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance
 All rights reserved. See LICENSE file and DISCLAIMER for more details.
 */
 #include "MpiBroker.h"
-#include "MpiComms.h"
-
 #include "../../common/argParser.h"
+#include "MpiComms.h"
+#include <iostream>
 
 #include <mpi.h>
 
@@ -87,19 +87,16 @@ bool MpiBroker::brokerConnect ()
     {
         setAsRoot ();
     }
-	else
-	{
+    else
+    {
         comms->setBrokerAddress (brokerAddress);
-	}
-    
+    }
+
     comms->setName (getIdentifier ());
 
-   return comms->connect ();
+    return comms->connect ();
 }
 
-std::string MpiBroker::generateLocalAddressString () const
-{
-    return comms->getAddress ();
-}
+std::string MpiBroker::generateLocalAddressString () const { return comms->getAddress (); }
 }  // namespace mpi
 }  // namespace helics

--- a/src/helics/core/mpi/MpiComms.cpp
+++ b/src/helics/core/mpi/MpiComms.cpp
@@ -7,6 +7,7 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 //#include "../../common/AsioServiceManager.h"
 #include "../ActionMessage.hpp"
 #include "MpiService.h"
+#include <iostream>
 #include <memory>
 
 namespace helics
@@ -20,19 +21,16 @@ MpiComms::MpiComms ()
     std::cout << "MpiComms() - commAddress = " << localTarget_ << std::endl;
 }
 
-
 /** destructor*/
 MpiComms::~MpiComms () { disconnect (); }
 
-
 void MpiComms::setBrokerAddress (const std::string &address)
-{ 
-	if (propertyLock())
-	{
+{
+    if (propertyLock ())
+    {
         brokerTarget_ = address;
         propertyUnLock ();
-	}
-	
+    }
 }
 
 int MpiComms::processIncomingMessage (ActionMessage &M)
@@ -53,7 +51,7 @@ int MpiComms::processIncomingMessage (ActionMessage &M)
 
 void MpiComms::queue_rx_function ()
 {
-   setRxStatus(connection_status::connected);
+    setRxStatus (connection_status::connected);
 
     while (true)
     {
@@ -63,7 +61,7 @@ void MpiComms::queue_rx_function ()
         {
             if (!isValidCommand (M.value ()))
             {
-                logError("invalid command received");
+                logError ("invalid command received");
                 continue;
             }
 
@@ -90,19 +88,19 @@ void MpiComms::queue_rx_function ()
 CLOSE_RX_LOOP:
     std::cout << "Shutdown RX Loop for " << localTarget_ << std::endl;
     shutdown = true;
-    setRxStatus(connection_status::terminated);
+    setRxStatus (connection_status::terminated);
 }
 
 void MpiComms::queue_tx_function ()
 {
-    setTxStatus( connection_status::connected);
+    setTxStatus (connection_status::connected);
 
     auto &mpi_service = MpiService::getInstance ();
 
-    std::map<route_id_t, std::pair<int,int>> routes;  // for all the other possible routes
+    std::map<route_id_t, std::pair<int, int>> routes;  // for all the other possible routes
 
-	 std::pair<int, int> brokerLocation;
-    if (!brokerTarget_.empty())
+    std::pair<int, int> brokerLocation;
+    if (!brokerTarget_.empty ())
     {
         hasBroker = true;
         auto addr_delim_pos = brokerTarget_.find (":");
@@ -129,10 +127,9 @@ void MpiComms::queue_tx_function ()
                     std::pair<int, int> routeLoc;
                     auto addr_delim_pos = cmd.payload.find (":");
                     routeLoc.first = std::stoi (cmd.payload.substr (0, addr_delim_pos));
-                    routeLoc.second =
-                      std::stoi (cmd.payload.substr (addr_delim_pos + 1, cmd.payload.length ()));
+                    routeLoc.second = std::stoi (cmd.payload.substr (addr_delim_pos + 1, cmd.payload.length ()));
 
-                    routes.emplace (route_id_t(cmd.getExtraData()), routeLoc);
+                    routes.emplace (route_id_t (cmd.getExtraData ()), routeLoc);
                     processed = true;
                 }
                 break;
@@ -185,11 +182,11 @@ void MpiComms::queue_tx_function ()
 CLOSE_TX_LOOP:
     std::cout << "Shutdown TX Loop for " << localTarget_ << std::endl;
     routes.clear ();
-    if (getRxStatus() == connection_status::connected)
+    if (getRxStatus () == connection_status::connected)
     {
         shutdown = true;
     }
-    setTxStatus(connection_status::terminated);
+    setTxStatus (connection_status::terminated);
     mpi_service.removeMpiComms (this);
 }
 

--- a/src/helics/core/mpi/MpiComms.cpp
+++ b/src/helics/core/mpi/MpiComms.cpp
@@ -8,6 +8,7 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #include "../ActionMessage.hpp"
 #include "MpiService.h"
 #include <iostream>
+#include <map>
 #include <memory>
 
 namespace helics

--- a/src/helics/core/tcp/TcpBroker.cpp
+++ b/src/helics/core/tcp/TcpBroker.cpp
@@ -8,6 +8,7 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #include "../NetworkBroker_impl.hpp"
 #include "TcpComms.h"
 #include "TcpCommsSS.h"
+#include <iostream>
 
 namespace helics
 {

--- a/src/helics/core/tcp/TcpComms.cpp
+++ b/src/helics/core/tcp/TcpComms.cpp
@@ -76,7 +76,7 @@ size_t TcpComms::dataReceive (std::shared_ptr<TcpConnection> connection, const c
     while (used_total < bytes_received)
     {
         ActionMessage m;
-        auto used = m.depacketize (data + used_total, bytes_received - used_total);
+        auto used = m.depacketize (data + used_total, static_cast<int> (bytes_received - used_total));
         if (used == 0)
         {
             break;

--- a/src/helics/core/tcp/TcpCommsSS.cpp
+++ b/src/helics/core/tcp/TcpCommsSS.cpp
@@ -100,7 +100,7 @@ size_t TcpCommsSS::dataReceive (std::shared_ptr<TcpConnection> connection, const
     while (used_total < bytes_received)
     {
         ActionMessage m;
-        auto used = m.depacketize (data + used_total, bytes_received - used_total);
+        auto used = m.depacketize (data + used_total, static_cast<int> (bytes_received - used_total));
         if (used == 0)
         {
             break;

--- a/src/helics/core/test/TestComms.cpp
+++ b/src/helics/core/test/TestComms.cpp
@@ -20,6 +20,7 @@ namespace testcore
 {
 TestComms::TestComms () : CommsInterface (CommsInterface::thread_generation::single) {}
 
+using namespace std::chrono;
 /** destructor*/
 TestComms::~TestComms () { disconnect (); }
 
@@ -86,7 +87,7 @@ void TestComms::queue_tx_function ()
 
     if (!brokerName_.empty ())
     {
-        std::chrono::milliseconds totalSleep (0);
+        milliseconds totalSleep (0);
         while (!tbroker)
         {
 
@@ -108,20 +109,20 @@ void TestComms::queue_tx_function ()
                         setRxStatus(connection_status::error);
                         return;
                     }
-                    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-                    totalSleep += std::chrono::milliseconds(200);
+                    std::this_thread::sleep_for(milliseconds(200));
+                    totalSleep += milliseconds(200);
                 }
             }
             else
             {
                 if (!tbroker->isOpenToNewFederates())
                 {
-                    std::cerr << "broker is not open to new federates " << brokerName_ << std::endl;
+					logError("broker is not open to new federates " + brokerName_);
                     tbroker = nullptr;
                     broker = nullptr;
-                    BrokerFactory::cleanUpBrokers(std::chrono::milliseconds(200));
-                    totalSleep += std::chrono::milliseconds(200);
-                    if (totalSleep > std::chrono::milliseconds(connectionTimeout))
+                    BrokerFactory::cleanUpBrokers(milliseconds(200));
+                    totalSleep += milliseconds(200);
+                    if (totalSleep > milliseconds(connectionTimeout))
                     {
                         setTxStatus(connection_status::error);
                         setRxStatus(connection_status::error);
@@ -133,7 +134,7 @@ void TestComms::queue_tx_function ()
     }
     else if (!serverMode)
     {
-        std::chrono::milliseconds totalSleep(0);
+        milliseconds totalSleep(0);
         while (!tbroker)
         {
             auto broker = BrokerFactory::findJoinableBrokerOfType(core_type::TEST);
@@ -154,8 +155,8 @@ void TestComms::queue_tx_function ()
                         setRxStatus(connection_status::error);
                         return;
                     }
-                    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-                    totalSleep += std::chrono::milliseconds(200);
+                    std::this_thread::sleep_for(milliseconds(200));
+                    totalSleep += milliseconds(200);
                 }
             }
         }

--- a/src/helics/core/zmq/ZmqComms.cpp
+++ b/src/helics/core/zmq/ZmqComms.cpp
@@ -37,7 +37,7 @@ static bool bindzmqSocket (zmq::socket_t &socket,
         {
             if (tcount == milliseconds (0))
             {
-                //std::cerr << "zmq binding error on socket sleeping then will try again \n";
+                // std::cerr << "zmq binding error on socket sleeping then will try again \n";
             }
             if (tcount > timeout)
             {
@@ -108,7 +108,8 @@ int ZmqComms::processIncomingMessage (zmq::message_t &msg)
     ActionMessage M (static_cast<char *> (msg.data ()), msg.size ());
     if (!isValidCommand (M))
     {
-		logError("invalid command received");
+        logError ("invalid command received");
+        ActionMessage Q (static_cast<char *> (msg.data ()), msg.size ());
         return 0;
     }
     if (isProtocolCommand (M))
@@ -143,11 +144,11 @@ int ZmqComms::replyToIncomingMessage (zmq::message_t &msg, zmq::socket_t &sock)
         return 0;
     }
 
-        ActionCallback (std::move (M));
-        ActionMessage resp (CMD_PRIORITY_ACK);
-        auto str = resp.to_string ();
-        sock.send (str.data (), str.size ());
-        return 0;
+    ActionCallback (std::move (M));
+    ActionMessage resp (CMD_PRIORITY_ACK);
+    auto str = resp.to_string ();
+    sock.send (str.data (), str.size ());
+    return 0;
 }
 
 void ZmqComms::queue_rx_function ()
@@ -193,7 +194,7 @@ void ZmqComms::queue_rx_function ()
             }
             else if (M.messageID == NAME_NOT_FOUND)
             {
-				logError(std::string("broker name ") + brokerName_ + " does not match broker connection");
+                logError (std::string ("broker name ") + brokerName_ + " does not match broker connection");
                 disconnecting = true;
                 setRxStatus (connection_status::error);
                 return;
@@ -526,7 +527,7 @@ void ZmqComms::queue_tx_function ()
                 }
                 else
                 {
-                    logError(e.what ());
+                    logError (e.what ());
                 }
             }
             continue;

--- a/src/helics/core/zmq/ZmqComms.cpp
+++ b/src/helics/core/zmq/ZmqComms.cpp
@@ -37,7 +37,7 @@ static bool bindzmqSocket (zmq::socket_t &socket,
         {
             if (tcount == milliseconds (0))
             {
-                std::cerr << "zmq binding error on socket sleeping then will try again \n";
+                //std::cerr << "zmq binding error on socket sleeping then will try again \n";
             }
             if (tcount > timeout)
             {
@@ -108,7 +108,7 @@ int ZmqComms::processIncomingMessage (zmq::message_t &msg)
     ActionMessage M (static_cast<char *> (msg.data ()), msg.size ());
     if (!isValidCommand (M))
     {
-        std::cerr << "invalid command received" << std::endl;
+		logError("invalid command received");
         return 0;
     }
     if (isProtocolCommand (M))
@@ -193,7 +193,7 @@ void ZmqComms::queue_rx_function ()
             }
             else if (M.messageID == NAME_NOT_FOUND)
             {
-                std::cout << "broker name " << brokerName_ << " does not match broker connection\n";
+				logError(std::string("broker name ") + brokerName_ + " does not match broker connection");
                 disconnecting = true;
                 setRxStatus (connection_status::error);
                 return;
@@ -526,7 +526,7 @@ void ZmqComms::queue_tx_function ()
                 }
                 else
                 {
-                    std::cerr << e.what () << '\n';
+                    logError(e.what ());
                 }
             }
             continue;

--- a/src/helics/core/zmq/ZmqRequestSets.cpp
+++ b/src/helics/core/zmq/ZmqRequestSets.cpp
@@ -7,6 +7,7 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #include "ZmqRequestSets.h"
 #include "helics_includes/optional.hpp"
 #include <algorithm>
+#include <iostream>
 
 namespace helics
 {

--- a/tests/helics/core/ActionMessage-tests.cpp
+++ b/tests/helics/core/ActionMessage-tests.cpp
@@ -275,7 +275,36 @@ BOOST_AUTO_TEST_CASE (conversion_test)
     setActionFlag (cmd, required_flag);
     setActionFlag (cmd, error_flag);
     cmd.actionTime = 45.7;
-    cmd.payload = "hello world";
+    cmd.payload = std::string (5000, 'a');
+
+    cmd.setStringData ("target", "source as a very long string test .........", "original_source");
+
+    auto cmdString = cmd.to_string ();
+
+    helics::ActionMessage cmd2 (cmdString);
+    BOOST_CHECK (cmd.action () == cmd2.action ());
+    BOOST_CHECK_EQUAL (cmd.actionTime, cmd2.actionTime);
+    BOOST_CHECK_EQUAL (cmd.source_id, cmd2.source_id);
+    BOOST_CHECK_EQUAL (cmd.dest_id, cmd2.dest_id);
+    BOOST_CHECK_EQUAL (cmd.source_handle, cmd2.source_handle);
+    BOOST_CHECK_EQUAL (cmd.dest_handle, cmd2.dest_handle);
+    BOOST_CHECK_EQUAL (cmd.payload, cmd2.payload);
+    BOOST_CHECK_EQUAL (cmd.flags, cmd2.flags);
+    BOOST_CHECK (cmd.getStringData () == cmd2.getStringData ());
+}
+
+BOOST_AUTO_TEST_CASE (conversion_test2)
+{
+    helics::ActionMessage cmd (helics::CMD_SEND_MESSAGE);
+    cmd.source_id = global_federate_id_t (1);
+    cmd.source_handle = interface_handle (2);
+    cmd.dest_id = global_federate_id_t (3);
+    cmd.dest_handle = interface_handle (4);
+    setActionFlag (cmd, iteration_requested_flag);
+    setActionFlag (cmd, required_flag);
+    setActionFlag (cmd, error_flag);
+    cmd.actionTime = 45.7;
+    cmd.payload = std::string (500000, 'j');
 
     cmd.setStringData ("target", "source as a very long string test .........", "original_source");
 

--- a/tests/helics/core/ActionMessage-tests.cpp
+++ b/tests/helics/core/ActionMessage-tests.cpp
@@ -5,8 +5,8 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 */
 #include <boost/test/unit_test.hpp>
 
-#include "helics/core/flagOperations.hpp"
 #include "helics/core/ActionMessage.hpp"
+#include "helics/core/flagOperations.hpp"
 #include <cstdio>
 #include <set>
 
@@ -31,10 +31,10 @@ BOOST_AUTO_TEST_CASE (action_test_to_string_conversion)
     */
     m.actionTime = 47.2342;
     m.payload = "this is a string that is sufficiently long";
-    m.source_handle = interface_handle(4);
-    m.source_id = global_federate_id_t(232324);
-    m.dest_id = global_federate_id_t(22552215);
-    m.dest_handle = interface_handle(2322342);
+    m.source_handle = interface_handle (4);
+    m.source_id = global_federate_id_t (232324);
+    m.dest_id = global_federate_id_t (22552215);
+    m.dest_handle = interface_handle (2322342);
 
     std::string data;
     m.to_string (data);
@@ -53,6 +53,46 @@ BOOST_AUTO_TEST_CASE (action_test_to_string_conversion)
 BOOST_AUTO_TEST_CASE (action_test_to_string_conversion_info)
 {
     helics::ActionMessage m (CMD_REG_INPUT);
+    /*
+    auto b = sizeof(m);
+    BOOST_CHECK_LT(b, 64);
+    if (b > 64)
+    {
+    printf("sizeof(extraInfo)=%d\n", static_cast<int>(sizeof(std::unique_ptr<ActionMessage::AdditionalInfo>)));
+    printf("payload %d\n", static_cast<int>(reinterpret_cast<char *>(&(m.extraInfo)) - reinterpret_cast<char
+    *>(&m)));
+    }
+    */
+    m.actionTime = 47.2342;
+    m.payload = "this is a string that is sufficiently long";
+    m.source_handle = interface_handle (4);
+    m.source_id = global_federate_id_t (232324);
+    m.dest_id = global_federate_id_t (22552215);
+    m.dest_handle = interface_handle (2322342);
+
+    m.setString (sourceStringLoc, "this is a long source string to test");
+    m.setString (origSourceStringLoc, "this is a longer alternate source string to test");
+    m.setString (targetStringLoc, "this is a target");
+
+    std::string data;
+    m.to_string (data);
+
+    ActionMessage fr;
+    fr.from_string (data);
+    BOOST_CHECK (m.action () == fr.action ());
+    BOOST_CHECK_EQUAL (m.payload, fr.payload);
+    BOOST_CHECK_EQUAL (m.source_handle, fr.source_handle);
+    BOOST_CHECK_EQUAL (m.source_id, fr.source_id);
+    BOOST_CHECK_EQUAL (m.dest_handle, fr.dest_handle);
+    BOOST_CHECK_EQUAL (m.dest_id, fr.dest_id);
+    BOOST_CHECK (m.actionTime == fr.actionTime);
+
+    BOOST_CHECK (m.getStringData () == fr.getStringData ());
+}
+
+BOOST_AUTO_TEST_CASE (action_test_to_string_conversion_info2)
+{
+    helics::ActionMessage m (CMD_TIME_REQUEST);
     /*
     auto b = sizeof(m);
     BOOST_CHECK_LT(b, 64);
@@ -102,9 +142,9 @@ BOOST_AUTO_TEST_CASE (constructor_test)
     helics::ActionMessage cmd;
     BOOST_CHECK (cmd.action () == helics::CMD_IGNORE);
     BOOST_CHECK_EQUAL (cmd.source_id, parent_broker_id);
-    BOOST_CHECK (!cmd.source_handle.isValid());
+    BOOST_CHECK (!cmd.source_handle.isValid ());
     BOOST_CHECK_EQUAL (cmd.dest_id, parent_broker_id);
-    BOOST_CHECK (!cmd.dest_handle.isValid());
+    BOOST_CHECK (!cmd.dest_handle.isValid ());
     BOOST_CHECK_EQUAL (cmd.counter, 0);
     BOOST_CHECK_EQUAL (cmd.flags, 0);
     BOOST_CHECK_EQUAL (cmd.actionTime, helics::Time::zeroVal ());
@@ -123,10 +163,10 @@ BOOST_AUTO_TEST_CASE (constructor_test)
 BOOST_AUTO_TEST_CASE (copy_constructor_test)
 {
     helics::ActionMessage cmd (helics::CMD_INIT);
-    cmd.source_id = global_federate_id_t(1);
-    cmd.source_handle = interface_handle(2);
-    cmd.dest_id = global_federate_id_t(3);
-    cmd.dest_handle = interface_handle(4);
+    cmd.source_id = global_federate_id_t (1);
+    cmd.source_handle = interface_handle (2);
+    cmd.dest_id = global_federate_id_t (3);
+    cmd.dest_handle = interface_handle (4);
     cmd.flags = 0x1a2F;  // this has no significance
     cmd.actionTime = helics::Time::maxVal ();
     cmd.payload = "hello world";
@@ -138,10 +178,10 @@ BOOST_AUTO_TEST_CASE (copy_constructor_test)
     // Check operator= override
     helics::ActionMessage cmd_copy (cmd);
     BOOST_CHECK (cmd_copy.action () == helics::CMD_INIT);
-    BOOST_CHECK_EQUAL (cmd_copy.source_id.baseValue(), 1);
-    BOOST_CHECK_EQUAL (cmd_copy.source_handle.baseValue(), 2);
-    BOOST_CHECK_EQUAL (cmd_copy.dest_id.baseValue(), 3);
-    BOOST_CHECK_EQUAL (cmd_copy.dest_handle.baseValue(), 4);
+    BOOST_CHECK_EQUAL (cmd_copy.source_id.baseValue (), 1);
+    BOOST_CHECK_EQUAL (cmd_copy.source_handle.baseValue (), 2);
+    BOOST_CHECK_EQUAL (cmd_copy.dest_id.baseValue (), 3);
+    BOOST_CHECK_EQUAL (cmd_copy.dest_handle.baseValue (), 4);
     BOOST_CHECK_EQUAL (cmd_copy.flags, 0x1a2F);
     BOOST_CHECK_EQUAL (cmd_copy.actionTime, helics::Time::maxVal ());
     BOOST_CHECK_EQUAL (cmd_copy.payload, "hello world");
@@ -174,10 +214,10 @@ BOOST_AUTO_TEST_CASE (assignment_test)
     // Check operator= override
     helics::ActionMessage cmd_assign = cmd;
     BOOST_CHECK (cmd_assign.action () == helics::CMD_INIT);
-    BOOST_CHECK_EQUAL (cmd_assign.source_id.baseValue(), 1);
-    BOOST_CHECK_EQUAL (cmd_assign.source_handle.baseValue(), 2);
-    BOOST_CHECK_EQUAL (cmd_assign.dest_id.baseValue(), 3);
-    BOOST_CHECK_EQUAL (cmd_assign.dest_handle.baseValue(), 4);
+    BOOST_CHECK_EQUAL (cmd_assign.source_id.baseValue (), 1);
+    BOOST_CHECK_EQUAL (cmd_assign.source_handle.baseValue (), 2);
+    BOOST_CHECK_EQUAL (cmd_assign.dest_id.baseValue (), 3);
+    BOOST_CHECK_EQUAL (cmd_assign.dest_handle.baseValue (), 4);
     BOOST_CHECK (checkActionFlag (cmd_assign, iteration_requested_flag));
     BOOST_CHECK (checkActionFlag (cmd_assign, required_flag));
     BOOST_CHECK (checkActionFlag (cmd_assign, error_flag));
@@ -237,8 +277,6 @@ BOOST_AUTO_TEST_CASE (conversion_test)
     cmd.actionTime = 45.7;
     cmd.payload = "hello world";
 
-    cmd.Te = 0.89;
-    cmd.Tdemin = 5.55;
     cmd.setStringData ("target", "source as a very long string test .........", "original_source");
 
     auto cmdString = cmd.to_string ();
@@ -252,8 +290,6 @@ BOOST_AUTO_TEST_CASE (conversion_test)
     BOOST_CHECK_EQUAL (cmd.dest_handle, cmd2.dest_handle);
     BOOST_CHECK_EQUAL (cmd.payload, cmd2.payload);
     BOOST_CHECK_EQUAL (cmd.flags, cmd2.flags);
-    BOOST_CHECK_EQUAL (cmd.Te, cmd2.Te);
-    BOOST_CHECK_EQUAL (cmd.Tdemin, cmd2.Tdemin);
     BOOST_CHECK (cmd.getStringData () == cmd2.getStringData ());
 }
 
@@ -270,8 +306,6 @@ BOOST_AUTO_TEST_CASE (message_message_conversion_test)
     cmd.actionTime = 45.7;
     cmd.payload = "hello world";
 
-    cmd.Te = 0.89;
-    cmd.Tdemin = 5.55;
     cmd.setStringData ("target", "source as a very long string test .........", "original_source");
 
     auto msg = helics::createMessageFromCommand (cmd);
@@ -330,8 +364,6 @@ BOOST_AUTO_TEST_CASE (check_packetization)
     cmd.actionTime = 45.7;
     cmd.payload = "hello world";
 
-    cmd.Te = 0.89;
-    cmd.Tdemin = 5.55;
     cmd.setStringData ("target", "source as a very long string test .........", "original_source");
     auto cmdStringNormal = cmd.to_string ();
     auto cmdString = cmd.packetize ();
@@ -347,8 +379,6 @@ BOOST_AUTO_TEST_CASE (check_packetization)
     BOOST_CHECK_EQUAL (cmd.dest_handle, cmd2.dest_handle);
     BOOST_CHECK_EQUAL (cmd.payload, cmd2.payload);
     BOOST_CHECK_EQUAL (cmd.flags, cmd2.flags);
-    BOOST_CHECK_EQUAL (cmd.Te, cmd2.Te);
-    BOOST_CHECK_EQUAL (cmd.Tdemin, cmd2.Tdemin);
     BOOST_CHECK (cmd.getStringData () == cmd2.getStringData ());
 }
 

--- a/tests/helics/core/ActionMessage-tests.cpp
+++ b/tests/helics/core/ActionMessage-tests.cpp
@@ -370,12 +370,12 @@ BOOST_AUTO_TEST_CASE (check_conversions)
     auto testBuffer1 = std::make_unique<char[]> (cmdStr.size () + 20);
     auto testBuffer2 = std::make_unique<char[]> (cmdStr.size () >> 2);  // make a too small buffer
 
-    auto res = cmd.toByteArray (testBuffer1.get (), cmdStr.size () + 20);
+    auto res = cmd.toByteArray (testBuffer1.get (), static_cast<int> (cmdStr.size () + 20));
     BOOST_CHECK_EQUAL (res, cmdStr.size ());
     // just check to make sure the same string was written
     BOOST_CHECK_EQUAL (cmdStr, std::string (testBuffer1.get (), res));
     // this should return -1
-    res = cmd.toByteArray (testBuffer2.get (), cmdStr.size () >> 2);
+    res = cmd.toByteArray (testBuffer2.get (), static_cast<int> (cmdStr.size () >> 2));
     BOOST_CHECK_EQUAL (res, -1);
 }
 
@@ -398,7 +398,7 @@ BOOST_AUTO_TEST_CASE (check_packetization)
     auto cmdString = cmd.packetize ();
     BOOST_CHECK_GE (cmdStringNormal.size () + 6, cmdString.size ());
     helics::ActionMessage cmd2;
-    auto res = cmd2.depacketize (cmdString.data (), cmdString.size ());
+    auto res = cmd2.depacketize (cmdString.data (), static_cast<int> (cmdString.size ()));
     BOOST_CHECK_EQUAL (res, cmdString.size ());
     BOOST_CHECK (cmd.action () == cmd2.action ());
     BOOST_CHECK_EQUAL (cmd.actionTime, cmd2.actionTime);

--- a/tests/helics/core/ActionMessage-tests.cpp
+++ b/tests/helics/core/ActionMessage-tests.cpp
@@ -8,6 +8,7 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #include "helics/core/flagOperations.hpp"
 #include "helics/core/ActionMessage.hpp"
 #include <cstdio>
+#include <set>
 
 namespace utf = boost::unit_test;
 

--- a/tests/helics/core/ZeromqCore-tests.cpp
+++ b/tests/helics/core/ZeromqCore-tests.cpp
@@ -20,6 +20,7 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #include "helics/common/GuardedTypes.hpp"
 //#include "boost/process.hpp"
 #include <future>
+#include <iostream>
 
 namespace utf = boost::unit_test;
 using namespace std::literals::chrono_literals;


### PR DESCRIPTION
<!--
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.

e.g.

This fixes issue #123
-->
Reduce headers for ActionMessage and use a custom serialization instead of cereal. 
This should improve performance somewhat, though most cases it probably won't be noticeable.    But it also improves compile time a little.  

- [ ] I have reviewed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] I agree to license my contributions under the same license as in this repository
- [ ] I have verified that the tests pass

### Description

Use a custom serialization of the ActionMessage, which reduces the size a little and should improve performance for some cases.  


