### PR TITLE
Cleanup unused headers and remove unneeded compiled Boost libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,9 +275,6 @@ set(
   program_options
   filesystem
   system
-  date_time
-  timer
-  chrono
 )
 if (BUILD_TESTING)
 	list(APPEND BOOST_REQUIRED_LIBRARIES unit_test_framework)

--- a/config/cmake/addBoost.cmake
+++ b/config/cmake/addBoost.cmake
@@ -1,5 +1,5 @@
 ##############################################################################
-#Copyright © 2017-2018,
+#Copyright Â© 2017-2018,
 #Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC
 #All rights reserved. See LICENSE file and DISCLAIMER for more details.
 ##############################################################################
@@ -98,7 +98,7 @@ endif(MSVC)
 HIDE_VARIABLE(BOOST_TEST_PATH)
 
 if (NOT BOOST_REQUIRED_LIBRARIES)
-	set(BOOST_REQUIRED_LIBRARIES program_options filesystem system date_time timer chrono)
+	set(BOOST_REQUIRED_LIBRARIES program_options filesystem system)
 	if (BUILD_TESTING)
 		message(STATUS "adding unit testing")
 		list(APPEND BOOST_REQUIRED_LIBRARIES unit_test_framework)

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -16,10 +16,10 @@ Python support.
 FROM ubuntu:18.04 as builder
 
 RUN apt update && apt install -y \
-  libboost-dev libboost-chrono-dev \
-  libboost-date-time-dev libboost-filesystem-dev \
+  libboost-dev \
+  libboost-filesystem-dev \
   libboost-program-options-dev \
-  libboost-test-dev libboost-timer-dev \
+  libboost-test-dev \
   libzmq5-dev python3-dev \
   build-essential swig cmake git
 
@@ -40,9 +40,8 @@ RUN make -j8 && make install
 FROM ubuntu:18.04
 
 RUN apt update && apt install -y --no-install-recommends \
-  libboost-chrono1.65.1 libboost-date-time1.65.1 \
   libboost-filesystem1.65.1 libboost-program-options1.65.1 \
-  libboost-test1.65.1 libboost-timer1.65.1 libzmq5
+  libboost-test1.65.1 libzmq5
 
 COPY --from=builder /helics /usr/local/
 

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -24,9 +24,6 @@ sudo apt-get install libboost-dev
 sudo apt-get install libboost-program-options-dev
 sudo apt-get install libboost-test-dev
 sudo apt-get install libboost-filesystem-dev
-sudo apt-get install libboost-date-time-dev
-sudo apt-get install libboost-timer-dev
-sudo apt-get install libboost-chrono-dev
 sudo apt-get install libzmq5-dev
 ```
 

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -198,14 +198,11 @@ $ cmake-gui ../
 If this failes that is because mingw-w64-x86_64-qt5 was not installed. If you did install it the cmake gui window should pop up. click the Advanced check box next to the search bar. Then click Configure. A window will pop up asking you to specify the generator for this project. Select MSYS Makesfiles from the dropdown menu. Then click the Specify native compilers check box and click next. Enter C:/msys64/mingw64/bin/gcc.exe for the C compiler and C:/msys64/mingw64/bin/g++.exe for the C++ compiler and click finish. Once the Configure process finished several variables will show up highlighted in red. Since this is the first time setup the Boost and ZeroMQ library. Below are the following cmake variables that need to be verified.
 
 * BUILD_CXX_SHARED_LIB should be checked as GridLAB-D dynamically links with the shared c++ library of HELICS
-* Boost_CHRONO_LIBRARY_DEBUG/RELEASE C:/msys64/mingw64/bin/libboost_chrono-mt.dll
-* Boost_DATE_TIME_LIBRARY_DEBUG/RELEASE C:/msys64/mingw64/bin/libboost_date_time-mt.dll
 * Boost_FILESYSTEM_LIBRARY_DEBUG/RELEASE C:/msys64/mingw64/bin/libboost_filesystem-mt.dll
 * Boost_INCLUDE_DIR C:/msys64/mingw64/include
 * Boost_LIBRARY_DIR_DEBUG/RELEASE C:/msys64/mingw64/bin
 * Boost_PROGRAM_OPTIONS_LIBRARY_DEBUG/RELEASE C:/msys64/mingw64/bin/libboost_program_options-mt.dll
 * Boost_SYSTEM_LIBRARY_DEBUG/RELEASE C:/msys64/mingw64/bin/libboost_system-mt.dll
-* Boost_TIMER_LIBRARY_DEBUG/RELEASE C:/msys64/mingw64/bin/libboost_timer-mt.dll
 * Boost_UNIT_TEST_FRAMEWORK_LIBRARY_DEBUG/RELEASE C:/msys64/mingw64/bin/libboost_unit_test_framework-mt.dll
 * CMAKE_CXX_FLAGS -std=gnu++14
 * CMAKE_INSTALL_PREFIX /usr/local or location of your choice

--- a/scripts/build_boost_clang.sh
+++ b/scripts/build_boost_clang.sh
@@ -6,7 +6,7 @@ cd ~/boost_1_66_0/
 
 
 #add mpi if building with mpi
-./bootstrap.sh --with-toolset=clang --prefix=$localdir/boost --with-libraries=system,test,program_options,filesystem,date_time
+./bootstrap.sh --with-toolset=clang --prefix=$localdir/boost --with-libraries=system,test,program_options,filesystem
 
 # change to "-std=c++1z" to build with C++17
 ./b2 install -j4 --prefix=$localdir/boost --build-dir=$localdir/buildboost toolset=clang variant=release link=static link=shared cxxflags="-std=c++14 -stdlib=libc++ -fPIC" linkflags="-stdlib=libc++ -fPIC" threading=multi address-model=64 

--- a/scripts/build_boost_gcc.sh
+++ b/scripts/build_boost_gcc.sh
@@ -6,7 +6,7 @@ localdir=$(pwd)
 cd ~/boost_1_66_0/
 
 #add mpi if building with mpi
-./bootstrap.sh --with-toolset=gcc --prefix=$localdir/boost --with-libraries=system,test,program_options,filesystem,date_time 
+./bootstrap.sh --with-toolset=gcc --prefix=$localdir/boost --with-libraries=system,test,program_options,filesystem 
 
 # change to "-std=c++1z" to build with C++17
 ./b2 install -j4 --prefix=$localdir/boost --build-dir=$localdir/buildboost toolset=gcc variant=release link=static link=shared cxxflags="-std=c++14 -fPIC" threading=multi address-model=64 

--- a/scripts/install-dependency.sh
+++ b/scripts/install-dependency.sh
@@ -158,7 +158,7 @@ install_boost () {
     fetch_and_untar ${boost_version_str}.tar.gz \
         http://sourceforge.net/projects/boost/files/boost/${boost_version}/${boost_version_str}.tar.gz/download
     cd ${boost_version_str}/;
-    ./bootstrap.sh --with-libraries=date_time,filesystem,program_options,system,chrono,timer,test --with-toolset=${boost_toolset};
+    ./bootstrap.sh --with-libraries=filesystem,program_options,system,test --with-toolset=${boost_toolset};
     ./b2 install -j2 --prefix=${install_path} \
         variant=release \
         link=${b2_link_type} \

--- a/src/helics/core/BrokerBase.cpp
+++ b/src/helics/core/BrokerBase.cpp
@@ -13,14 +13,10 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #include "../common/fmt_format.h"
 #include "ForwardingTimeCoordinator.hpp"
 #include "flagOperations.hpp"
-#include "helics/helics-config.h"
-#include "helicsVersion.hpp"
 #include <iostream>
 #include <libguarded/guarded.hpp>
 #include <random>
 #include <boost/asio/steady_timer.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/program_options.hpp>
 #include "loggingHelper.hpp"
 
 static constexpr auto chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";

--- a/src/helics/core/CMakeLists.txt
+++ b/src/helics/core/CMakeLists.txt
@@ -206,6 +206,9 @@ target_compile_definitions(
   helics_core PRIVATE
   $<TARGET_PROPERTY:helics_base_includes,INTERFACE_COMPILE_DEFINITIONS>
 )
+target_compile_definitions(
+  helics_core PRIVATE BOOST_DATE_TIME_NO_LIB
+)
 target_compile_options(
   helics_core
   PRIVATE $<TARGET_PROPERTY:helics_base_includes,INTERFACE_COMPILE_OPTIONS>

--- a/src/helics/core/CommonCore.cpp
+++ b/src/helics/core/CommonCore.cpp
@@ -27,7 +27,6 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #include <cstring>
 #include <fstream>
 #include <functional>
-#include <boost/filesystem.hpp>
 
 #include "../common/DelayedObjects.hpp"
 #include "../common/JsonProcessingFunctions.hpp"

--- a/src/helics/core/CoreBroker.cpp
+++ b/src/helics/core/CoreBroker.cpp
@@ -10,7 +10,6 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 
 #include "../common/argParser.h"
 #include "../common/fmt_format.h"
-#include <boost/filesystem.hpp>
 
 #include "../common/JsonProcessingFunctions.hpp"
 #include "../common/logger.h"
@@ -20,7 +19,6 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #include "helics_definitions.hpp"
 #include "loggingHelper.hpp"
 #include "queryHelpers.hpp"
-#include <fstream>
 #include <iostream>
 
 namespace helics

--- a/src/helics/core/ipc/IpcComms.cpp
+++ b/src/helics/core/ipc/IpcComms.cpp
@@ -11,7 +11,6 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #include <algorithm>
 #include <cctype>
 #include <memory>
-#include "boost/date_time/posix_time/posix_time.hpp"
 #include <boost/interprocess/ipc/message_queue.hpp>
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/interprocess/sync/interprocess_mutex.hpp>

--- a/src/helics/core/ipc/IpcQueueHelper.cpp
+++ b/src/helics/core/ipc/IpcQueueHelper.cpp
@@ -8,10 +8,9 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 #include <thread>
 
 #include <boost/date_time/posix_time/ptime.hpp>
-
 #include <boost/date_time/microsec_time_clock.hpp>
-
 #include <boost/date_time/local_time/local_time.hpp>
+
 namespace boostipc = boost::interprocess;
 
 namespace helics

--- a/tests/helics/core/CMakeLists.txt
+++ b/tests/helics/core/CMakeLists.txt
@@ -51,6 +51,9 @@ add_executable(core-tests ${core_test_sources} ${core_test_headers})
 target_link_libraries(core-tests helics-static helics_test_base)
 
 target_include_directories(core-tests PRIVATE ${PROJECT_SOURCE_DIR}/src)
+target_compile_definitions(
+  core-tests PRIVATE BOOST_DATE_TIME_NO_LIB
+)
 set_target_properties(core-tests PROPERTIES FOLDER tests)
 
 add_test(NAME core-tests COMMAND core-tests --log_level=test_suite --report_level=short)


### PR DESCRIPTION
- [x] I have reviewed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I agree to license my contributions under the same license as in this repository
- [x] I have verified that the tests pass

### Description

Removes some unused headers and compiled Boost libraries that aren't used, reduces the number of Boost libraries that need to be compiled while building for CI or installed with apt.

### Proposed changes

- Remove some headers that are included but not used from several source files
- Remove unused compiled Boost libraries; chrono isn't used (std::chrono is used instead), timer isn't needed (for C++11 compilers, std::chrono is used internally), and compiled parts of date_time aren't used
- Remove unused compiled Boost libraries from libraries to build on Travis and in build instruction documents

