### PR TITLE
Disable building Python/Java interfaces for Travis CI code analysis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ jobs:
       os: osx
       compiler: clang
       env:
-        - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=73"
+        - MATRIX_EVAL="COMPILER=clang && BUILD_TYPE=Release && TRAVIS_XCODE_VERSION=8gm"
         - HOMEBREW_NO_AUTO_UPDATE=1
       osx_image: xcode8
 
@@ -135,6 +135,7 @@ jobs:
         - MATRIX_EVAL="COMPILER=gcc && CC=gcc-6 && CXX=g++-6"
         - USE_SWIG=true
         - RUN_VALGRIND=true
+        - DISABLE_INTERFACES="Python,Java"
         - BUILD_TYPE=RelWithDebInfo
     # Code coverage build
     - <<: *daily_linux
@@ -144,6 +145,7 @@ jobs:
         - USE_SWIG=true 
         - TEST_TYPE=Coverage
         - BUILD_TYPE=Coverage
+        - DISABLE_INTERFACES="Python,Java"
         - GCOV_TOOL=gcov-6
         - USE_MPI=mpich
         - CTEST_VERBOSE=true
@@ -191,6 +193,7 @@ jobs:
         - MATRIX_EVAL="COMPILER=clang && CC='clang-4.0' && CXX='clang++-4.0'"
         - CCACHE_CPP2=yes
         - CI_TEST_CONFIG="TSAN"
+        - DISABLE_INTERFACES="Python,Java"
         - RUN_TSAN=true
         - USE_MPI=mpich
         - JOB_OPTION_FLAGS="-C../scripts/tsan-cache.cmake"
@@ -209,6 +212,7 @@ jobs:
       env:
         - MATRIX_EVAL="COMPILER=clang && CC='clang-4.0' && CXX='clang++-4.0'"
         - CCACHE_CPP2=yes
+        - DISABLE_INTERFACES="Python,Java"
         - RUN_UBSAN=true
         - USE_MPI=mpich
         - JOB_OPTION_FLAGS="-C../scripts/ubsan-cache.cmake"
@@ -232,9 +236,12 @@ install:
   - export BOOST_USE_STATIC=true
   - source scripts/install-ci-dependencies.sh
 
+  - SHELLNOCASEMATCH=$(shopt -p nocasematch; true)
+  - shopt -s nocasematch
   - OPTION_FLAGS_ARR=()
-  - OPTION_FLAGS_ARR+=("-DBUILD_C_SHARED_LIB=ON" "-DBUILD_SHARED_LIBS=ON" "-DBUILD_PYTHON_INTERFACE=ON" "-DBUILD_JAVA_INTERFACE=ON" "-DEXAMPLES_WARNINGS_AS_ERROR=ON")
-  - OPTION_FLAGS_ARR+=("-DPYTHON_LIBRARY=${PYTHON_LIB_PATH}" "-DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_PATH}")
+  - OPTION_FLAGS_ARR+=("-DBUILD_C_SHARED_LIB=ON" "-DBUILD_SHARED_LIBS=ON" "-DEXAMPLES_WARNINGS_AS_ERROR=ON")
+  - if [[ "${DISABLE_INTERFACES}" != *"Java"* ]]; then OPTION_FLAGS_ARR+=("-DBUILD_JAVA_INTERFACE=ON") ; fi
+  - if [[ "${DISABLE_INTERFACES}" != *"Python"* ]]; then OPTION_FLAGS_ARR+=("-DBUILD_PYTHON_INTERFACE=ON" "-DPYTHON_LIBRARY=${PYTHON_LIB_PATH}" "-DPYTHON_INCLUDE_DIR=${PYTHON_INCLUDE_PATH}") ; fi
   - OPTION_FLAGS_ARR+=("-DZMQ_USE_STATIC_LIBRARY=ON -DUSE_BOOST_STATIC_LIBS=ON")
 
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then OPTION_FLAGS_ARR+=("-DDISABLE_SYSTEM_CALL_TESTS=ON") ; fi
@@ -261,7 +268,8 @@ install:
   - if [[ "$CTEST_VERBOSE" ]]; then TEST_FLAGS_ARR+=("--ctest-verbose") ; fi
   - if [[ "$DISABLE_CI_TESTS" ]]; then TEST_FLAGS_ARR+=("--disable-unit-tests") ; fi
   - export CI_TEST_FLAGS=${TEST_FLAGS_ARR[@]}
-
+  - $SHELLNOCASEMATCH
+  
 script:
   - mkdir -p build && cd build
   - HELICS_DEPENDENCY_FLAGS+="-DBOOST_INSTALL_PATH=${CI_DEPENDENCY_DIR}/boost"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <tr>
   <td>Coverage</td>
   <td><a href="https://codecov.io/gh/GMLC-TDC/HELICS-src"><img src="https://codecov.io/gh/GMLC-TDC/HELICS-src/branch/master/graph/badge.svg" alt="codecov" /></a></td>
-  <td><a href="https://codecov.io/gh/GMLC-TDC/HELICS-src"><img src="https://codecov.io/gh/GMLC-TDC/HELICS-src/branch/develop/graph/badge.svg" alt="codecov" /></a></td>
+  <td><a href="https://codecov.io/gh/GMLC-TDC/HELICS-src/branch/HELICS_2_0"><img src="https://codecov.io/gh/GMLC-TDC/HELICS-src/branch/HELICS_2_0/graph/badge.svg" alt="codecov" /></a></td>
   </tr>
   <tr>
   <td>Gitter</td>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <tr>
   <td>Coverage</td>
   <td><a href="https://codecov.io/gh/GMLC-TDC/HELICS-src"><img src="https://codecov.io/gh/GMLC-TDC/HELICS-src/branch/master/graph/badge.svg" alt="codecov" /></a></td>
-  <td><a href="https://codecov.io/gh/GMLC-TDC/HELICS-src/branch/HELICS_2_0"><img src="https://codecov.io/gh/GMLC-TDC/HELICS-src/branch/HELICS_2_0/graph/badge.svg" alt="codecov" /></a></td>
+  <td><a href="https://codecov.io/gh/GMLC-TDC/HELICS-src/branch/develop"><img src="https://codecov.io/gh/GMLC-TDC/HELICS-src/branch/develop/graph/badge.svg" alt="codecov" /></a></td>
   </tr>
   <tr>
   <td>Gitter</td>


### PR DESCRIPTION
- [x] I have reviewed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I agree to license my contributions under the same license as in this repository
- [ ] I have verified that the tests pass

### Description

Disable Python/Java interfaces for certain build types. And update the codecov link for the develop branch badge. Addresses issues raised in #470.

### Proposed changes

- Link the develop codecov badge to the codecov page for the develop branch
- Add a mechanism for disabling building language interfaces on Travis
- Disable the Python/Java interface builds for the Travis Valgrind, sanitizer, and code coverage builds

