### PR TITLE
Allow trigger dependent repositories step to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ jobs:
   allow_failures:
     - os: osx
     - name: "Clang 4 Thread Sanitizer"
+    - stage: trigger dependent repositories
 
   include:
     # XCode 6.4, OS X 10.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ jobs:
   allow_failures:
     - os: osx
     - name: "Clang 4 Thread Sanitizer"
-    - stage: trigger dependent repositories
+    - script: scripts/trigger-dependent-ci-builds.sh
 
   include:
     # XCode 6.4, OS X 10.10


### PR DESCRIPTION
- [x] I have reviewed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I agree to license my contributions under the same license as in this repository
- [x] I have verified that the tests pass

Allows the trigger dependent repositories step to fail (or be cancelled). Travis only allows ~10 api requests for starting builds per hour anyway.
