### PR TITLE
update the timeout used in zmq comms

### DIFF
--- a/src/helics/core/NetworkBrokerData.cpp
+++ b/src/helics/core/NetworkBrokerData.cpp
@@ -24,6 +24,7 @@ static const ArgDescriptors extraArgs{
   {"broker,b"s,
    "identifier for the broker, this is either the name or network address use --broker_address or --brokername to explicitly set the network address or name the search for the broker is first by name"s},
   {"broker_address"s, "location of the broker i.e network address"s},
+  {"network_retries"s, ArgDescriptor::arg_type_t::int_type, "the maximum number of network retries"s},
   {"brokername"s, "the name of the broker"s},
   {"brokerinit"s, "the initialization string for the broker"s},
   {"max_size"s, ArgDescriptor::arg_type_t::int_type, "maximum message buffer size (16*1024)"s},
@@ -155,6 +156,10 @@ void NetworkBrokerData::initializeFromArgs (int argc, const char *const *argv, c
         {
             maxMessageSize = msize;
         }
+    }
+    if (vm.count ("network_retries") > 0)
+    {
+        maxRetries = vm["network_retries"].as<int> ();
     }
     if (vm.count ("os_port") > 0)
     {

--- a/src/helics/core/NetworkBrokerData.hpp
+++ b/src/helics/core/NetworkBrokerData.hpp
@@ -10,22 +10,22 @@ All rights reserved. See LICENSE file and DISCLAIMER for more details.
 namespace helics
 {
 /** define the network access*/
-enum class interface_networks :char
+enum class interface_networks : char
 {
     local,  //!< just open local ports
     ipv4,  //!< use external ipv4 ports
     ipv6,  //!< use external ipv6 ports
-    all, //!< use all external ports
+    all,  //!< use all external ports
 };
 
 /** define keys for particular interfaces*/
-enum class interface_type :char
+enum class interface_type : char
 {
     tcp = 0,  //!< using tcp ports for communication
     udp = 1,  //!< using udp ports for communication
     ip = 2,  //!< using both types of ports (tcp/or udp) for communication
-    ipc = 3, //!< using ipc locations
-    inproc=4, //!< using inproc sockets for communications
+    ipc = 3,  //!< using ipc locations
+    inproc = 4,  //!< using inproc sockets for communications
 };
 
 /** helper class designed to contain the common elements between networking brokers and cores
@@ -33,15 +33,14 @@ enum class interface_type :char
 class NetworkBrokerData
 {
   public:
-   
-	enum class server_mode_options :char
-	{
-		unspecified = 0,
-		server_default_active=1,
-		server_default_deactivated=2,
-		server_active = 3,
-		server_deactivated=4,
-	};
+    enum class server_mode_options : char
+    {
+        unspecified = 0,
+        server_default_active = 1,
+        server_default_deactivated = 2,
+        server_active = 3,
+        server_deactivated = 4,
+    };
 
     std::string brokerName;  //!< the identifier for the broker
     std::string brokerAddress;  //!< the address or domain name of the broker
@@ -50,13 +49,15 @@ class NetworkBrokerData
     int portNumber = -1;  //!< the port number for the local interface
     int brokerPort = -1;  //!< the port number to use for the main broker interface
     int portStart = -1;  //!< the starting port for automatic port definitions
-	int maxMessageSize = 16 * 256; //!< maximum message size
-	int maxMessageCount = 256; //!< maximum message count
+    int maxMessageSize = 16 * 256;  //!< maximum message size
+    int maxMessageCount = 256;  //!< maximum message count
+    int maxRetries = 5;  //!< the maximum number of retries to establish a network connection
     interface_networks interfaceNetwork = interface_networks::local;
-    bool reuse_address = false; //!< allow reuse of binding address
-    bool use_os_port = false;  //!< specify that any automatic port allocation should use operating system allocation
+    bool reuse_address = false;  //!< allow reuse of binding address
+    bool use_os_port =
+      false;  //!< specify that any automatic port allocation should use operating system allocation
     bool autobroker = false;  //!< flag for specifying an automatic broker generation
-	server_mode_options server_mode = server_mode_options::unspecified; //!< setup a server mode
+    server_mode_options server_mode = server_mode_options::unspecified;  //!< setup a server mode
   public:
     NetworkBrokerData () = default;
     /** constructor from the allowed type*/
@@ -78,7 +79,6 @@ class NetworkBrokerData
     /** do some checking on the brokerAddress*/
     void checkAndUpdateBrokerAddress (const std::string &localAddress);
     interface_type allowedType = interface_type::ip;
-    
 };
 
 /** generate a string with a full address based on an interface string and port number
@@ -110,7 +110,7 @@ std::pair<std::string, std::string> extractInterfaceandPortString (const std::st
 
 /** strip any protocol strings from the interface and return a new string
 @example tcp://127.0.0.1 -> 127.0.0.1*/
-std::string stripProtocol(const std::string &networkAddress);
+std::string stripProtocol (const std::string &networkAddress);
 /** strip any protocol strings from the interface and return a new string*/
 void removeProtocol (std::string &networkAddress);
 
@@ -123,26 +123,27 @@ void insertProtocol (std::string &networkAddress, interface_type interfaceT);
 /** check if a specified address is v6 or v4
 @return true if the address is a v6 address
 */
-bool isipv6(const std::string &address);
+bool isipv6 (const std::string &address);
 
 /** get the external ipv4 address of the current computer
  */
 std::string getLocalExternalAddressV4 ();
 
 /** get the external ipv4 Ethernet address of the current computer that best matches the listed server*/
-std::string getLocalExternalAddress(const std::string &server);
+std::string getLocalExternalAddress (const std::string &server);
 
 /** get the external ipv4 Ethernet address of the current computer that best matches the listed server*/
 std::string getLocalExternalAddressV4 (const std::string &server);
 
 /** get the external ipv4 address of the current computer
-*/
-std::string getLocalExternalAddressV6();
+ */
+std::string getLocalExternalAddressV6 ();
 
 /** get the external ipv4 Ethernet address of the current computer that best matches the listed server*/
-std::string getLocalExternalAddressV6(const std::string &server);
+std::string getLocalExternalAddressV6 (const std::string &server);
 
 /** generate an interface that matches a defined server or network specification
-*/
-std::string generateMatchingInterfaceAddress(const std::string &server, interface_networks network=interface_networks::local);
+ */
+std::string generateMatchingInterfaceAddress (const std::string &server,
+                                              interface_networks network = interface_networks::local);
 }  // namespace helics

--- a/src/helics/core/NetworkCommsInterface.cpp
+++ b/src/helics/core/NetworkCommsInterface.cpp
@@ -84,6 +84,7 @@ void NetworkCommsInterface::loadNetworkInfo (const NetworkBrokerData &netInfo)
     }
     brokerPort = netInfo.brokerPort;
     PortNumber = netInfo.portNumber;
+    maxRetries = netInfo.maxRetries;
     switch (networkType)
     {
     case interface_type::tcp:

--- a/src/helics/core/NetworkCommsInterface.hpp
+++ b/src/helics/core/NetworkCommsInterface.hpp
@@ -43,33 +43,36 @@ class NetworkCommsInterface : public CommsInterface
     virtual void loadNetworkInfo (const NetworkBrokerData &netInfo) override;
     /** set the port numbers for the local ports*/
     void setBrokerPort (int brokerPortNumber);
+    /** set the local port number to use for incoming connections*/
     void setPortNumber (int localPortNumber);
+    /** set the automatic port numbering starting port*/
     void setAutomaticPortStartPort (int startingPort);
+    /** set a flag on the communication system*/
     virtual void setFlag (const std::string &flag, bool val) override;
 
   protected:
     int brokerPort = -1;
     std::atomic<int> PortNumber{-1};
     bool autoPortNumber = true;
-    bool useOsPortAllocation = false;
+    bool useOsPortAllocation = false;  //!< use the operating system to allocate a port number
     const interface_type networkType;
     interface_networks network = interface_networks::ipv4;
     std::atomic<bool> hasBroker{false};
+    int maxRetries = 5;  // the maximum number of network retries
 
   private:
-    PortAllocator openPorts;
+    PortAllocator openPorts;  //!< a structure to deal with port allocations
 
   public:
     /** find an open port for a subBroker*/
     int findOpenPort (int count, const std::string &host);
     /** for protocol messages some require an immediate reply from the comms interface itself*/
     ActionMessage generateReplyToIncomingMessage (ActionMessage &cmd);
-    // promise and future for communicating port number from tx_thread to rx_thread
 
   public:
     /** get the port number of the comms object to push message to*/
     int getPort () const { return PortNumber; };
-
+    /** get the network address of the comms interface*/
     std::string getAddress () const;
     /** return the default Broker port*/
     virtual int getDefaultBrokerPort () const = 0;

--- a/src/helics/core/zmq/ZmqComms.cpp
+++ b/src/helics/core/zmq/ZmqComms.cpp
@@ -344,17 +344,30 @@ int ZmqComms::initializeBrokerConnections (zmq::socket_t &controlSocket)
                 brokerReq.send (str);
                 poller.socket = static_cast<void *> (brokerReq);
                 poller.events = ZMQ_POLLIN;
-                auto rc = zmq::poll (&poller, 1, connectionTimeout);
-                if (rc < 0)
+                int rc = 0;
+                int cnt2 = 0;
+                while (rc == 0)
                 {
-                    logError ("unable to connect with zmq broker (2)");
-                    setTxStatus (connection_status::error);
+                    rc = zmq::poll (&poller, 1, connectionTimeout);
+                    if (rc < 0)
+                    {
+                        logError ("unable to connect with zmq broker (2)");
+                        setTxStatus (connection_status::error);
+                        break;
+                    }
+                    else if (rc == 0)
+                    {
+                        logWarning ("zmq broker connection timed out, trying again (2)");
+                    }
+                    ++cnt2;
+                    if (cnt2 > 5)
+                    {
+                        logError ("zmq broker connection timed out after trying 5 times (2)");
+                        setTxStatus (connection_status::error);
+                        break;
+                    }
                 }
-                else if (rc == 0)
-                {
-                    logError ("zmq broker connection timed out (2)");
-                    setTxStatus (connection_status::error);
-                }
+
                 if (getTxStatus () == connection_status::error)
                 {
                     ActionMessage M (CMD_PROTOCOL);

--- a/src/helics/core/zmq/ZmqComms.cpp
+++ b/src/helics/core/zmq/ZmqComms.cpp
@@ -344,7 +344,7 @@ int ZmqComms::initializeBrokerConnections (zmq::socket_t &controlSocket)
                 brokerReq.send (str);
                 poller.socket = static_cast<void *> (brokerReq);
                 poller.events = ZMQ_POLLIN;
-                auto rc = zmq::poll (&poller, 1, std::chrono::milliseconds (3000));
+                auto rc = zmq::poll (&poller, 1, connectionTimeout);
                 if (rc < 0)
                 {
                     logError ("unable to connect with zmq broker (2)");

--- a/src/helics/core/zmq/ZmqCommsSS.cpp
+++ b/src/helics/core/zmq/ZmqCommsSS.cpp
@@ -358,7 +358,7 @@ void ZmqCommsSS::queue_tx_function ()
 
         // Handle Tx messages first
         auto tx_msg = txQueue.try_pop ();
-        rc = zmq::poll (poller, std::chrono::milliseconds (10));
+        rc = zmq::poll (poller, 0l);
         if (!tx_msg || (rc <= 0))
         {
             std::this_thread::yield ();
@@ -449,7 +449,7 @@ void ZmqCommsSS::queue_tx_function ()
         rc = 1;
         while ((rc > 0) && (count < 5))
         {
-            rc = zmq::poll (poller, std::chrono::milliseconds (10));
+            rc = zmq::poll (poller, 0l);
 
             if (rc > 0)
             {


### PR DESCRIPTION

<!--
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.

e.g.

This fixes issue #123
-->

- [x] I have reviewed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I agree to license my contributions under the same license as in this repository
- [x] I have verified that the tests pass

### Description

This partially addresses Issue #578

### Proposed changes

<!-- Describe the proposed changes of Pull Request here -->

- Have the timeout on the ZMQ comms use the connectionTimeout variable from CommInterface instead of hard coded value
- use 0 timeout for some zmqComms_ss since 10ms was not particularly useful.  

