### PR TITLE
Update variant.hpp to include constexpr fix for VS2017 15.9

### DIFF
--- a/ThirdParty/helics_includes/variant.hpp
+++ b/ThirdParty/helics_includes/variant.hpp
@@ -247,7 +247,7 @@ namespace std {
 #endif
 
 #if defined(__cpp_constexpr) && __cpp_constexpr >= 201304 && \
-    !(defined(_MSC_VER) && _MSC_VER <= 1915)
+    !(defined(_MSC_VER) && _MSC_VER <= 1916)
 #define MPARK_CPP14_CONSTEXPR
 #endif
 


### PR DESCRIPTION
- [x] I have reviewed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I agree to license my contributions under the same license as in this repository
- [x] I have verified that the tests pass

### Description

Include VS2017 version 15.9 in the compiler versions affected by the constexpr compiler bug.
