### PR TITLE
Fix uploading Travis CI artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ jobs:
         - CI_BOOST_VERSION=1.61.0
         - ENABLE_CPACK=true
         - INSTALL_SYSTEM_LIBRARIES=true
-      after_script: scripts/upload-ci-artifact.sh
+      after_script: ${TRAVIS_BUILD_DIR}/scripts/upload-ci-artifact.sh
 
     - <<: *linux_base
       name: "Clang 3.6"

--- a/scripts/upload-ci-artifact.sh
+++ b/scripts/upload-ci-artifact.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+CI_DIR=${TRAVIS_BUILD_DIR}
+
 # Upload artifact to Bintray
 BT_URL="https://api.bintray.com/content/helics/develop/snapshot/${TRAVIS_BRANCH}/${TRAVIS_BRANCH}/helics-install-$(uname -s).sh?publish=1&override=1"
-curl -T $(ls build/cpack-output/Helics*.sh) -u${BT_USER}:${BT_APIKEY} ${BT_URL}
+curl -T $(ls ${CI_DIR}/build/cpack-output/Helics*.sh) -u${BT_USER}:${BT_APIKEY} ${BT_URL}


### PR DESCRIPTION
- [x] I have reviewed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I agree to license my contributions under the same license as in this repository
- [x] I have verified that the tests pass

### Description

Fixes paths for uploading CI artifacts built on Travis to BinTray, for use in HELICS-FMI builds.