### PR TITLE
modify the export lines on the cmake

### DIFF
--- a/src/helics/CMakeLists.txt
+++ b/src/helics/CMakeLists.txt
@@ -20,13 +20,10 @@ add_library(
   $<TARGET_OBJECTS:helics_common>
 )
 
-target_link_libraries(helics-static PUBLIC helics_base)
+target_link_libraries(helics-static PUBLIC helics_base helics_base_includes)
 # add and alias library to match the find_package
 add_library(HELICS::helics-static ALIAS helics-static)
-target_include_directories(
-  helics-static
-  INTERFACE $<TARGET_PROPERTY:helics_base_includes,INTERFACE_INCLUDE_DIRECTORIES>
-)
+
 if(BUILD_SHARED_LIBS)
   add_library(
     helics-shared
@@ -38,11 +35,7 @@ if(BUILD_SHARED_LIBS)
   )
 
   add_library(HELICS::helics-shared ALIAS helics-shared)
-  target_link_libraries(helics-shared PRIVATE helics_base)
-  target_include_directories(
-    helics-shared
-    INTERFACE $<TARGET_PROPERTY:helics_base_includes,INTERFACE_INCLUDE_DIRECTORIES>
-  )
+  target_link_libraries(helics-shared PRIVATE helics_base helics_base_includes)
 
   if(WIN32)
     set_target_properties(helics-shared PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)


### PR DESCRIPTION
The generate expression was getting copied into the cmake-targets export file.  On import this line got copied into the targets,  and if the linkage was passed through to a higher level target the generate expression failed to evaluate.  Which meant HELICS had to be imported at the top level or it would fail.  The modification removes the generate expression and directly uses the target which should work fine in the export
