### PR TITLE
Fix typo in comboFed example for command line arg

### DIFF
--- a/examples/comboFederates1/comboFed.cpp
+++ b/examples/comboFederates1/comboFed.cpp
@@ -15,7 +15,7 @@ static const helics::ArgDescriptors InfoArgs{
   {"startbroker", "start a broker with the specified arguments"},
   {"target,t", "name of the target federate"},
   {"valuetarget", "name of the value federate to target"},
-  {"messgetarget", "name of the message federate to target"},
+  {"messagetarget", "name of the message federate to target"},
   {"endpoint,e", "name of the target endpoint"},
   {"source,s", "name of the source endpoint"}
   // name is captured in the argument processor for federateInfo


### PR DESCRIPTION

- [x] I have reviewed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I agree to license my contributions under the same license as in this repository ([BSD 3 clause](../LICENSE))

### Description

Fixes a typo in the argument name recognized in the comboFederate example.