### PR TITLE
Autoupdate git submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,11 @@ endif(GENERATE_DOXYGEN_DOC)
 # add_definitions(-DWIN32_LEAN_AND_MEAN) endif()
 
 # -------------------------------------------------------------
+# Update git submodules
+# -------------------------------------------------------------
+include(updateGitSubmodules)
+
+# -------------------------------------------------------------
 # BOOST  find the boost libraries
 # -------------------------------------------------------------
 

--- a/config/cmake/updateGitSubmodules.cmake
+++ b/config/cmake/updateGitSubmodules.cmake
@@ -2,13 +2,15 @@ find_package(Git QUIET)
 if(GIT_FOUND AND (GIT_VERSION_STRING VERSION_GREATER "1.5.2"))
     if(EXISTS "${PROJECT_SOURCE_DIR}/.git")
         option(UPDATE_GIT_SUBMODULE "Checkout and update git submodules" ON)
-        message(STATUS "Git Submodule Update")
-        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init
-                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                        RESULT_VARIABLE GIT_RESULT
-                        OUTPUT_VARIABLE GIT_OUTPUT)
-        if(GIT_RESULT)
-            message(WARNING "Automatic submodule checkout with `git submodule --init` failed with error ${GIT_RESULT} and output ${GIT_OUTPUT}. Checkout the submodules before building.")
+        if(UPDATE_GIT_SUBMODULE)
+            message(STATUS "Git Submodule Update")
+            execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init
+                            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                            RESULT_VARIABLE GIT_RESULT
+                            OUTPUT_VARIABLE GIT_OUTPUT)
+            if(GIT_RESULT)
+                message(WARNING "Automatic submodule checkout with `git submodule --init` failed with error ${GIT_RESULT} and output ${GIT_OUTPUT}. Checkout the submodules before building.")
+            endif()
         endif()
     else()
         message(STATUS "${PROJECT_SOURCE_DIR} is not a Git repository. Clone ${PROJECT_NAME} with Git or ensure you get copies of all the Git submodules code.")

--- a/config/cmake/updateGitSubmodules.cmake
+++ b/config/cmake/updateGitSubmodules.cmake
@@ -1,0 +1,16 @@
+find_package(Git QUIET)
+if(GIT_FOUND AND (GIT_VERSION_STRING VERSION_GREATER "1.5.2"))
+    if(EXISTS "${PROJECT_SOURCE_DIR}/.git")
+        option(UPDATE_GIT_SUBMODULE "Checkout and update git submodules" ON)
+        message(STATUS "Git Submodule Update")
+        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init
+                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                        RESULT_VARIABLE GIT_RESULT
+                        OUTPUT_VARIABLE GIT_OUTPUT)
+        if(GIT_RESULT)
+            message(WARNING "Automatic submodule checkout with `git submodule --init` failed with error ${GIT_RESULT} and output ${GIT_OUTPUT}. Checkout the submodules before building.")
+        endif()
+    else()
+        message(STATUS "${PROJECT_SOURCE_DIR} is not a Git repository. Clone ${PROJECT_NAME} with Git or ensure you get copies of all the Git submodules code.")
+    endif()
+endif()


### PR DESCRIPTION
### Description
If merged this pull request will add an option to the CMake configure step to ensure that the git submodules are initialized and updated.

### Proposed changes
- Add an update git submodules script to the CMake build process to automatically download git submodules (issue #675)
