### PR TITLE
Add sstream header to JsonProcessingFunctions

### DIFF
--- a/src/helics/application_api/queryFunctions.cpp
+++ b/src/helics/application_api/queryFunctions.cpp
@@ -10,8 +10,6 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "Federate.hpp"
 #include <thread>
 
-#include "json/json.h"
-
 #include <boost/algorithm/string.hpp>
 
 std::vector<std::string> vectorizeQueryResult (std::string &&queryres)

--- a/src/helics/common/JsonProcessingFunctions.cpp
+++ b/src/helics/common/JsonProcessingFunctions.cpp
@@ -7,6 +7,7 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "JsonProcessingFunctions.hpp"
 #include <fstream>
+#include <sstream>
 
 bool hasJsonExtension (const std::string &jsonString)
 {


### PR DESCRIPTION
### Description

If merged this pull request will include the sstream header to JsonProcessingFunctions.cpp to fix a compile error encountered on MSVC.

### Proposed changes
- Add sstream header to JsonProcessingFunctions.cpp to fix compile error
- Remove JsonCpp include from a file that doesn't use it
