### PR TITLE
Run packaging tests on one build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ jobs:
         - CI_BOOST_VERSION=1.61.0
         - ENABLE_CPACK=true
         - INSTALL_SYSTEM_LIBRARIES=true
-        - SKIP_TEST_RUN=true
+        - TEST_TYPE=Packaging
       after_script: ${TRAVIS_BUILD_DIR}/scripts/upload-ci-artifact.sh
 
     - <<: *linux_base

--- a/.travis.yml
+++ b/.travis.yml
@@ -177,7 +177,7 @@ jobs:
         - CCACHE_CPP2=yes
         - CI_TEST_CONFIG="TSAN"
         - DISABLE_INTERFACES="Python,Java"
-        - RUN_TSAN=true
+        - RUN_SANITIZER=tsan
         - USE_MPI=mpich
         - JOB_OPTION_FLAGS="-C../scripts/tsan-cache.cmake"
     # UBSAN build
@@ -196,7 +196,7 @@ jobs:
         - MATRIX_EVAL="COMPILER=clang && CC='clang-5.0' && CXX='clang++-5.0'"
         - CCACHE_CPP2=yes
         - DISABLE_INTERFACES="Python,Java"
-        - RUN_UBSAN=true
+        - RUN_SANITIZER=ubsan
         - USE_MPI=mpich
         - JOB_OPTION_FLAGS="-C../scripts/ubsan-cache.cmake"
       

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ after_build:
 
 test_script:
   - cd build
-  - ctest --output-on-failure --timeout 480 -C Release -L Continuous
+  - ctest --output-on-failure --timeout 480 -C Release -L "Continuous|Packaging"
   - cd ..
 
 artifacts:

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -127,7 +127,7 @@ if [[ "$os_name" == "Linux" ]]; then
     if [[ ! -d "${boost_install_path}" ]]; then
         echo "*** build boost"
         local boost_sanitizer=""
-        if [[ "$RUN_TSAN" ]]; then
+        if [[ "$RUN_SANITIZER" == "tsan" ]]; then
             boost_sanitizer="BOOST_SANITIZER=thread"
         fi
         ${BOOST_SANITIZER} ${WAIT_COMMAND} ./scripts/install-dependency.sh boost ${boost_version} ${boost_install_path}

--- a/scripts/setup-helics-ci-options.sh
+++ b/scripts/setup-helics-ci-options.sh
@@ -78,18 +78,9 @@ if [[ "$RUN_CACHEGRIND" ]]; then
     TEST_FLAGS_ARR+=("--cachegrind")
 fi
 
-# Sanitizer tests
-if [[ "$RUN_ASAN" ]]; then
-    TEST_FLAGS_ARR+=("--asan")
-fi
-if [[ "$RUN_MSAN" ]]; then
-    TEST_FLAGS_ARR+=("--msan")
-fi
-if [[ "$RUN_TSAN" ]]; then
-    TEST_FLAGS_ARR+=("--tsan")
-fi
-if [[ "$RUN_UBSAN" ]]; then
-    TEST_FLAGS_ARR+=("--ubsan")
+# Sanitizer tests (supported: asan, msan, tsan, ubsan)
+if [[ "$RUN_SANITIZER" ]]; then
+    TEST_FLAGS_ARR+=("--${RUN_SANITIZER}")
 fi
 
 # Misc options

--- a/tests/helics/CMakeLists.txt
+++ b/tests/helics/CMakeLists.txt
@@ -32,6 +32,7 @@ add_subdirectory(apps)
 add_subdirectory(performance_tests)
 endif()
 
+
 # Tests for other CMake projects including and using HELICS
 add_test(find-package-tests ${CMAKE_CTEST_COMMAND} -C ${CMAKE_BUILD_TYPE}
                             --build-and-test "${CMAKE_CURRENT_SOURCE_DIR}/find_package_tests" "${CMAKE_CURRENT_BINARY_DIR}/find_package_tests"
@@ -46,4 +47,4 @@ add_test(find-package-tests ${CMAKE_CTEST_COMMAND} -C ${CMAKE_BUILD_TYPE}
                             "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
                             "-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}"
 )
-set_property(TEST find-package-tests PROPERTY LABELS Continuous Daily)
+set_property(TEST find-package-tests PROPERTY LABELS Packaging)


### PR DESCRIPTION
### Description

<!-- please finish the following statement -->
If merged this pull request will run the in buildtree find_package test only on the gcc 4.9.3 builds (not running the rest of the test suite) by replacing the Daily/Continuous ctest labels with a Packaging label. This resolves the ubsan linking errors (#685) when attempting to run the test on the daily build.

### Proposed changes
- Replaces RUN_<sanitizer> environment variables on Travis for test scripts with a RUN_SANITIZER=<sanitizer> variable
- Use the "Packaging" CTest label for find_package tests instead of "Daily" and "Continuous" labels
- Run "Packaging" tests on gcc 4.9.3 build (runs on commit and daily)
