### PR TITLE
Fix VS2019 build by adding missing string header

### DIFF
--- a/src/helics/core/JsonMapBuilder.hpp
+++ b/src/helics/core/JsonMapBuilder.hpp
@@ -7,6 +7,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #pragma once
 #include <map>
 #include <memory>
+#include <string>
 
 namespace Json
 {


### PR DESCRIPTION
### Description
If merged this pull request will add a missing string header to JsonMapBuilder.hpp that MSVC2019 complains about, to make HELICS compiler with VS2019. Errors due to the missing header can be seen at line 200 of [this HELICS-Examples build log](https://dev.azure.com/HELICS-test/HELICS-Examples/_build/results?buildId=505&view=logs&jobId=022b0a5d-2698-5f72-7610-a845972a8b4c&taskId=fb4a47ce-9e3e-59af-1bc9-5f0d015ee903&lineStart=200&lineEnd=201&colStart=1&colEnd=1)
### Proposed changes
- Add string header to JsonMapBuilder.hpp
