### PR TITLE
Clean-up the RTD navigation and fix the RTD build

### DIFF
--- a/docs/doxygen/index.md
+++ b/docs/doxygen/index.md
@@ -1,0 +1,1 @@
+# C++ API Reference (Doxygen)

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,24 +18,39 @@ Brief History: HELICS began as the core software development of the Grid Moderni
 
 Motivation: Energy systems and their associated information and communication technology systems are becoming increasingly intertwined. As a result, effectively designing, analyzing, and implementing modern energy systems increasingly relies on advanced modeling that simultaneously captures both the cyber and physical domains in combined simulations. It is designed to increase scalability and portability in modeling advanced features of highly integrated power system and cyber-physical energy systems.
 
-
-- [GitHub](https://github.com/GMLC-TDC/HELICS-src)
 - [Gitter](https://gitter.im/GMLC-TDC/HELICS-src)
-- [Documentation](https://helics.readthedocs.io/en/latest)
-- [User Guide](user-guide/index.html)
 
 ```eval_rst
 .. toctree::
- :maxdepth: 1
+   :maxdepth: 1
+   :caption: Basics
+   installation/index
+   introduction/index
+   user-guide/index
+```
 
- installation/index
- introduction/index
- configuration/index
- user-guide/index
- developer-guide/index
- apps/index
- c-api-reference/index
- ROADMAP
+```eval_rst
+.. toctree::
+   :maxdepth: 1
+   :caption: Reference
+   configuration/index
+   apps/index
+```
+
+```eval_rst
+.. toctree::
+   :maxdepth: 1
+   :caption: API Docs
+   c-api-reference/index
+   doxygen/index
+```
+
+```eval_rst
+.. toctree::
+   :maxdepth: 1
+   :caption: Contributing
+   developer-guide/index
+   ROADMAP
 ```
 
 You can find [Doxygen documentation here](doxygen/index.html).

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ Motivation: Energy systems and their associated information and communication te
 .. toctree::
    :maxdepth: 1
    :caption: Basics
+
    installation/index
    introduction/index
    user-guide/index
@@ -33,6 +34,7 @@ Motivation: Energy systems and their associated information and communication te
 .. toctree::
    :maxdepth: 1
    :caption: Reference
+
    configuration/index
    apps/index
 ```
@@ -41,6 +43,7 @@ Motivation: Energy systems and their associated information and communication te
 .. toctree::
    :maxdepth: 1
    :caption: API Docs
+
    c-api-reference/index
    doxygen/index
 ```
@@ -49,6 +52,7 @@ Motivation: Energy systems and their associated information and communication te
 .. toctree::
    :maxdepth: 1
    :caption: Contributing
+
    developer-guide/index
    ROADMAP
 ```

--- a/src/helics/core/helicsCLI11.hpp
+++ b/src/helics/core/helicsCLI11.hpp
@@ -1,5 +1,5 @@
 /*
-Copyright © 2017-2019,
+Copyright Â© 2017-2019,
 Battelle Memorial Institute; Lawrence Livermore National Security, LLC; Alliance for Sustainable Energy, LLC.  See
 the top-level NOTICE for additional details. All rights reserved.
 SPDX-License-Identifier: BSD-3-Clause


### PR DESCRIPTION
### Description
If merged this pull request will clean up the ReadTheDocs navigation sidebar with sections and a link to the Doxygen for the version being viewed. Convert helicsCLI11.hpp to utf-8 to fix the RTD build.

### Proposed changes
- Convert helicsCLI11.hpp encoding to utf-8
- Organize ReadTheDocs navigation into sections
- Add a link to the sidebar for the Doxygen matching the version of the docs being viewed
