### PR TITLE
Message timer fixes

### DIFF
--- a/config/cmake/FindZeroMQ.cmake
+++ b/config/cmake/FindZeroMQ.cmake
@@ -164,13 +164,25 @@ find_library(
     PATHS /lib /usr/lib /usr/local/lib
 )
 
+if (ZeroMQ_REQUIRE_HEADERS)
+if(ZeroMQ_INCLUDE_DIR)
 if(
     (ZeroMQ_LIBRARY AND NOT ZeroMQ_LIBRARY-NOTFOUND)
     OR (ZeroMQ_STATIC_LIBRARY AND NOT ZeroMQ_STATIC_LIBRARY-NOTFOUND)
 )
     set(ZeroMQ_FOUND 1)
 endif()
+endif()
+else(ZeroMQ_REQUIRE_HEADERS)
+if(
+    (ZeroMQ_LIBRARY AND NOT ZeroMQ_LIBRARY-NOTFOUND)
+    OR (ZeroMQ_STATIC_LIBRARY AND NOT ZeroMQ_STATIC_LIBRARY-NOTFOUND)
+)
+    set(ZeroMQ_FOUND 1)
+endif()
+endif(ZeroMQ_REQUIRE_HEADERS)
 
+if (ZeroMQ_FOUND)
 # Create shared library target
 if(ZeroMQ_LIBRARY AND NOT ZeroMQ_LIBRARY-NOTFOUND)
     message(STATUS "Found ZeroMQ library: ${ZeroMQ_LIBRARY}")
@@ -222,9 +234,9 @@ if(ZeroMQ_STATIC_LIBRARY AND NOT ZeroMQ_STATIC_LIBRARY-NOTFOUND)
         )
     endif()
 endif()
+endif()
 
-# show the ZeroMQ_INCLUDE_DIR and ZeroMQ_LIBRARY variables only in the advanced
-# view
+# show the variables only in the advanced view
 mark_as_advanced(
     ZeroMQ_ROOT_DIR
     ZeroMQ_INCLUDE_DIR

--- a/config/cmake/addZeroMQ.cmake
+++ b/config/cmake/addZeroMQ.cmake
@@ -43,6 +43,9 @@ option(
 
 mark_as_advanced(ZMQ_USE_STATIC_LIBRARY)
 
+#flag that zeromq headers are required
+set(ZeroMQ_REQUIRE_HEADERS ON)
+
 if(USE_SYSTEM_ZEROMQ_ONLY)
     find_package(ZeroMQ)
 elseif (ZMQ_FORCE_SUBPROJECT)
@@ -86,11 +89,11 @@ else()
         )
     endif()
 
-    if(NOT ZeroMQ_FOUND OR NOT ZeroMQ_INCLUDE_DIR)
+    if(NOT ZeroMQ_FOUND)
         # message(STATUS "initialZMQ not found")
 		set(ZeroMQ_FIND_QUIETLY ON)
         find_package(ZeroMQ)
-        if(NOT ZeroMQ_FOUND OR NOT ZeroMQ_INCLUDE_DIR)
+        if(NOT ZeroMQ_FOUND)
            if(ZMQ_SUBPROJECT)
               include(addlibzmq)
            endif()

--- a/src/helics/core/BrokerFactory.cpp
+++ b/src/helics/core/BrokerFactory.cpp
@@ -193,6 +193,10 @@ std::shared_ptr<Broker> create (core_type type, const std::string &configureStri
 std::shared_ptr<Broker> create (core_type type, const std::string &broker_name, const std::string &configureString)
 {
     auto broker = makeBroker (type, broker_name);
+    if (!broker)
+    {
+        throw (helics::RegistrationFailure ("unable to create broker"));
+    }
     broker->configure (configureString);
     bool reg = registerBroker (broker);
     if (!reg)
@@ -241,7 +245,7 @@ std::shared_ptr<Broker> create (core_type type, const std::string &broker_name, 
 
 /** lambda function to join cores before the destruction happens to avoid potential problematic calls in the
  * loops*/
-static auto destroyerCallFirst = [] (auto &broker) {
+static auto destroyerCallFirst = [](auto &broker) {
     broker->processDisconnect (
       true);  // use true here as it is possible the searchableObjectHolder is deleted already
     broker->joinAllThreads ();
@@ -317,7 +321,7 @@ static bool isJoinableBrokerOfType (core_type type, const std::shared_ptr<Broker
 
 std::shared_ptr<Broker> findJoinableBrokerOfType (core_type type)
 {
-    return searchableObjects.findObject ([type] (auto &ptr) { return isJoinableBrokerOfType (type, ptr); });
+    return searchableObjects.findObject ([type](auto &ptr) { return isJoinableBrokerOfType (type, ptr); });
 }
 
 bool registerBroker (const std::shared_ptr<Broker> &broker)
@@ -354,7 +358,7 @@ void unregisterBroker (const std::string &name)
 {
     if (!searchableObjects.removeObject (name))
     {
-        searchableObjects.removeObject ([&name] (auto &obj) { return (obj->getIdentifier () == name); });
+        searchableObjects.removeObject ([&name](auto &obj) { return (obj->getIdentifier () == name); });
     }
 }
 

--- a/src/helics/core/CoreFactory.cpp
+++ b/src/helics/core/CoreFactory.cpp
@@ -218,6 +218,10 @@ std::shared_ptr<Core> create (core_type type, const std::string &configureString
 std::shared_ptr<Core> create (core_type type, const std::string &core_name, const std::string &configureString)
 {
     auto core = makeCore (type, core_name);
+    if (!core)
+    {
+        throw (helics::RegistrationFailure ("unable to create core"));
+    }
     core->configure (configureString);
     registerCore (core);
 

--- a/src/helics/core/MessageTimer.hpp
+++ b/src/helics/core/MessageTimer.hpp
@@ -8,9 +8,9 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "../common/AsioContextManager.h"
 #include "ActionMessage.hpp"
+#include <asio/steady_timer.hpp>
 #include <memory>
 #include <mutex>
-#include <asio/steady_timer.hpp>
 
 namespace helics
 {
@@ -48,10 +48,10 @@ class MessageTimer : public std::enable_shared_from_this<MessageTimer>
 
   private:
     std::mutex timerLock;  //!< lock protecting the timer buffers
-    std::vector<std::shared_ptr<asio::steady_timer>> timers;
-    const std::function<void(ActionMessage &&)> sendFunction;  //!< the callback to use when sending a message
     std::vector<ActionMessage> buffers;
     std::vector<time_type> expirationTimes;
+    const std::function<void(ActionMessage &&)> sendFunction;  //!< the callback to use when sending a message
+    std::vector<std::shared_ptr<asio::steady_timer>> timers;
     std::shared_ptr<AsioContextManager> contextPtr;  //!< context manager to for handling real time operations
     decltype (contextPtr->startContextLoop ()) loopHandle;  //!< loop controller for async real time operations
 };

--- a/tests/helics/core/MessageTimerTests.cpp
+++ b/tests/helics/core/MessageTimerTests.cpp
@@ -21,10 +21,19 @@ TEST (messageTimer_tests, basic_test)
     std::this_thread::sleep_for (std::chrono::milliseconds (300));
     if (M.load ().action () != CMD_PROTOCOL)
     {
-        std::this_thread::sleep_for (std::chrono::milliseconds (500));
+        std::this_thread::sleep_for (std::chrono::milliseconds (300));
+    }
+    if (M.load ().action () != CMD_PROTOCOL)
+    {
+        std::cout << "having to wait again";
+        std::this_thread::sleep_for (std::chrono::milliseconds (200));
     }
     auto tm = M.load ();
     EXPECT_TRUE (tm.action () == CMD_PROTOCOL) << tm;
+    if (tm.action () != CMD_PROTOCOL)
+    {
+        mtimer->cancelAll ();
+    }
 }
 
 TEST (messageTimer_tests_skip_ci, basic_test_update)

--- a/tests/helics/core/MessageTimerTests.cpp
+++ b/tests/helics/core/MessageTimerTests.cpp
@@ -15,7 +15,7 @@ using namespace std::literals::chrono_literals;
 TEST (messageTimer_tests, basic_test)
 {
     libguarded::atomic_guarded<ActionMessage> M;
-    auto cback = [&](ActionMessage &&m) { M = std::move (m); };
+    auto cback = [&M](ActionMessage &&m) { M = std::move (m); };
     auto mtimer = std::make_shared<MessageTimer> (cback);
     std::this_thread::yield ();  // just get the loop started
     auto index=mtimer->addTimerFromNow (200ms, CMD_PROTOCOL);
@@ -26,6 +26,11 @@ TEST (messageTimer_tests, basic_test)
     {
         std::this_thread::sleep_for (300ms);
     }
+	if (M.load().action() != CMD_PROTOCOL)
+	{
+		std::cout << "waiting Again" << std::endl;
+		std::this_thread::sleep_for(300ms);
+	}
 	if (M.load().action() != CMD_PROTOCOL)
 	{
 		std::this_thread::sleep_for(300ms);

--- a/tests/helics/core/MessageTimerTests.cpp
+++ b/tests/helics/core/MessageTimerTests.cpp
@@ -26,12 +26,32 @@ TEST (messageTimer_tests, basic_test)
     {
         std::this_thread::sleep_for (300ms);
     }
+	if (M.load().action() != CMD_PROTOCOL)
+	{
+		std::this_thread::sleep_for(300ms);
+	}
     auto tm = M.load ();
-    EXPECT_TRUE (tm.action () == CMD_PROTOCOL) << tm;
+    EXPECT_TRUE (tm.action () == CMD_PROTOCOL) << "current = "<<prettyPrintString(tm);
     if (tm.action () != CMD_PROTOCOL)
     {
         mtimer->cancelAll ();
     }
+}
+TEST(messageTimer_tests, shorttime_test)
+{
+	libguarded::atomic_guarded<ActionMessage> M;
+	auto cback = [&](ActionMessage &&m) { M = std::move(m); };
+	auto mtimer = std::make_shared<MessageTimer>(cback);
+	auto index = mtimer->addTimerFromNow(0ms, CMD_PROTOCOL);
+	EXPECT_EQ(index, 0);
+	
+	std::this_thread::sleep_for(5ms);
+	auto tm = M.load();
+	EXPECT_TRUE(tm.action() == CMD_PROTOCOL) << "current = " << prettyPrintString(tm);
+	if (tm.action() != CMD_PROTOCOL)
+	{
+		mtimer->cancelAll();
+	}
 }
 
 TEST (messageTimer_tests_skip_ci, basic_test_update)

--- a/tests/helics/core/TestCore-tests.cpp
+++ b/tests/helics/core/TestCore-tests.cpp
@@ -19,7 +19,7 @@ using namespace helics::CoreFactory;
 
 TEST (TestCore_tests, testcore_initialization_test)
 {
-    auto broker = helics::BrokerFactory::create (helics::core_type::TEST, std::string ());
+    auto broker = helics::BrokerFactory::create (helics::core_type::TEST, std::string{});
     ASSERT_TRUE (broker);
     EXPECT_TRUE (broker->isConnected ());
     std::string configureString = std::string ("-f 4") + " --broker=" + broker->getIdentifier ();


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  

Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g.

This fixes issue #123-->

### Description

<!-- please finish the following statement -->
If merged this pull request will fix a recurring sporadic issue with the message Timer and some potential ZMQ issues if ZMQ happened to be installed on Windows without the headers.  

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- reorder some operations in the message timer to eliminate a potential pathway for stack corruption
- deal with the case of an expired timer starting out.  
- add an additional test case to specifically test the expired timer pathway.  
- use the chrono literals to clean up code.  
