### PR TITLE
Install misc docs to the standard GNU/FHS directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The main focus of this minor release is cleaning up the build system and extract
    - remove included fmt code and replace with submodule
    - remove jsoncpp code and replace with a submodule which generates a compiled library- this removed the need to continually regenerate the single header/file with customized namespaces, though if you are manually including helics the HELICS::jsoncpp needs to be added as a library.
    - extract several containers used in HELICS to a separate repository for better maintenance and possible reuse elsewhere.  Any reference to the containers library was removed from the Public API.
-   - All required references to boost were removed from the public API.  
+   - all required references to boost were removed from the public API.  
    - the logger headers were split into two sections.  The logger.h which includes the logger objects for use in federates was split from the loggerCore which is not publicly accessible.  
    - The command line arguments are error checked and the help prints all available options (thanks to CLI11)
    - the core tests and common tests now use google test instead of boost test.  More tests are expected to be migrated in the future.  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -746,8 +746,8 @@ install(
 )
 
 install(
-    FILES LICENSE NOTICE
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/helics
+    FILES LICENSE NOTICE CHANGELOG.md README.md
+    DESTINATION ${CMAKE_INSTALL_DOCDIR}
     COMPONENT libs
 )
 # -------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ A [Users guide](https://helics.readthedocs.io/en/latest/user-guide/index.html) f
 
 ## Documentation
 
-Our GitHub pages provides a set of [documentation](https://helics.readthedocs.io/en/latest/index.html) including a set of introductory [examples](https://helics.readthedocs.io/en/latest/introduction/index.html), a [developers guide](https://helics.readthedocs.io/en/latest/developer-guide/index.html), complete doxygen generated [API documentation](https://helics.readthedocs.io/en/latest/doxygen/annotated.html), and more.  A few more questions and answers are available on the [Wiki](https://github.com/GMLC-TDC/HELICS-src/wiki).
+Our ReadTheDocs site provides a set of [documentation](https://helics.readthedocs.io/en/latest/index.html) including a set of introductory [examples](https://helics.readthedocs.io/en/latest/introduction/index.html), a [developers guide](https://helics.readthedocs.io/en/latest/developer-guide/index.html), complete doxygen generated [API documentation](https://helics.readthedocs.io/en/latest/doxygen/annotated.html), and more.  A few more questions and answers are available on the [Wiki](https://github.com/GMLC-TDC/HELICS-src/wiki).
 
 Additionally, our initial requirements document can be found [here](docs/introduction/original_specification.md), which describes a number of our early design considerations.
 


### PR DESCRIPTION
### Description
If merged this pull request will install miscellaneous documents (LICENSE, NOTICE, README.md, CHANGELOG.md) to the [standard GNU install directory](https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html) for docs (also conforms with the [Filesystem Hierarchy Standard](http://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html)). The files could also be installed to the DATADIR, instead of the doc subfolder -- though it looks like most packages put these types of files in the doc subfolder.

### Proposed changes
- Add README.md and CHANGELOG.md to the files installed
- Install LICENSE, NOTICE, CHANGELOG.md, and README.md to the GNU docdir
- Change the README to say ReadTheDocs instead of GitHub for documentation links
- Make all bullets for changes in 2.1 start with a lower-case letter
