### PR TITLE
Allow any value for CXX_STANDARD env var on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,7 @@ jobs:
         - MATRIX_EVAL="COMPILER=clang && CC='clang-5.0' && CXX='clang++-5.0'"
         - CCACHE_CPP2=yes
         - USE_SWIG=true
+        - USE_CMAKE_VERSION=3.14.5
         - CXX_STANDARD=17
 
     - <<: *linux_base

--- a/scripts/setup-helics-ci-options.sh
+++ b/scripts/setup-helics-ci-options.sh
@@ -58,8 +58,8 @@ if [[ "$USE_MPI" ]]; then
 fi
 
 # Compiler/language options
-if [[ "$CXX_STANDARD" == "17" ]]; then
-    OPTION_FLAGS+=("-DCMAKE_CXX_STANDARD=17")
+if [[ "$CXX_STANDARD" ]]; then
+    OPTION_FLAGS+=("-DCMAKE_CXX_STANDARD=${CXX_STANDARD}")
 fi
 
 # Travis related options

--- a/scripts/setup-helics-ci-options.sh
+++ b/scripts/setup-helics-ci-options.sh
@@ -59,7 +59,7 @@ fi
 
 # Compiler/language options
 if [[ "$CXX_STANDARD" ]]; then
-    OPTION_FLAGS+=("-DCMAKE_CXX_STANDARD=${CXX_STANDARD}")
+    OPTION_FLAGS_ARR+=("-DCMAKE_CXX_STANDARD=${CXX_STANDARD}")
 fi
 
 # Travis related options


### PR DESCRIPTION
### Description
If merged this pull request will allow the CXX_STANDARD env var on Travis used for setting up the CMake options to be set to any value (14, 17, 20, etc). Using 17 or higher may require a user to have newer versions of CMake (3.8+) and/or compiler than the minimum required to build HELICS.

This fixes issue #693.

### Proposed changes
- Allows any value for CXX_STANDARD in the env var on Travis
- Fix the Travis CI CXX_STANDARD=17 test (wrong variable was getting set with the CMake option)
- Use CMake 3.14.5 for the Clang 5 Travis build (CMake 3.4 doesn't support C++17)
