### PR TITLE
Get rid of GCC 4.9.3 missing-field-initializers warning

### DIFF
--- a/src/helics/shared_api_library/MessageFederateExport.cpp
+++ b/src/helics/shared_api_library/MessageFederateExport.cpp
@@ -425,7 +425,7 @@ helics_message helicsEndpointGetMessage (helics_endpoint endpoint)
 
     if (endObj->lastMessage)
     {
-        helics_message mess{};
+        helics_message mess;
         mess.data = endObj->lastMessage->data.data ();
         mess.dest = endObj->lastMessage->dest.c_str ();
         mess.length = endObj->lastMessage->data.size ();
@@ -452,7 +452,7 @@ helics_message helicsFederateGetMessage (helics_federate fed)
 
     if (fedObj->lastMessage)
     {
-        helics_message mess{};
+        helics_message mess;
         mess.data = fedObj->lastMessage->data.data ();
         mess.dest = fedObj->lastMessage->dest.c_str ();
         mess.length = fedObj->lastMessage->data.size ();


### PR DESCRIPTION
### Description
If merged this pull request will remove the empty field initializer list. For some reason gcc 4.9.3 has issues with it and prints warnings.

### Proposed changes
- Remove the empty field initializer list when creating a helics_message object in the shared API library
